### PR TITLE
Add e2e test for secret request lifecycle

### DIFF
--- a/e2e/secret-request.test.ts
+++ b/e2e/secret-request.test.ts
@@ -1,0 +1,131 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+test.describe.configure({ mode: 'serial' });
+
+const email = process.env.E2E_USER_EMAIL || 'e2e@scrt.link';
+const password = process.env.E2E_USER_PASSWORD || 'foobar123';
+
+let page: Page;
+let requestLink: string;
+let receiptId: string;
+
+const noteText = 'Please provide secret.';
+const responseText = 'Some secret';
+
+test.beforeAll(async ({ browser }) => {
+	page = await browser.newPage();
+});
+
+test.afterAll(async () => {
+	await page.close();
+});
+
+test('Login and navigate to requests', async () => {
+	// Login
+	await page.goto('/login');
+	await page.getByTestId('input-email').fill(email);
+
+	const emailResponse = page.waitForResponse((r) => r.url().includes('?/loginWithEmail'));
+	await page.getByTestId('submit-email').click();
+	await emailResponse;
+
+	await page.waitForURL('**/login/password', { timeout: 10000 });
+	await page.waitForLoadState('networkidle');
+
+	const passwordInput = page.getByTestId('input-password');
+	await passwordInput.click();
+	await passwordInput.fill(password);
+	await expect(passwordInput).toHaveValue(password);
+
+	const submitBtn = page.getByTestId('submit-login');
+	await expect(submitBtn).toBeEnabled();
+	await Promise.all([page.waitForURL(/\/account/, { timeout: 15000 }), submitBtn.click()]);
+
+	expect(page.url()).toMatch(/\/account/);
+});
+
+test('Create a secret request with note', async () => {
+	await page.goto('/account/requests');
+	await page.waitForLoadState('networkidle');
+
+	// Wait for encryption key to be restored and form to be ready
+	await expect(page.getByTestId('input-request-note')).toBeVisible({ timeout: 15000 });
+
+	// Fill in the note
+	await page.getByTestId('input-request-note').fill(noteText);
+
+	// Submit the request
+	await expect(page.getByTestId('submit-request')).toBeEnabled({ timeout: 10000 });
+	const responsePromise = page.waitForResponse((r) => r.url().includes('?/postSecretRequest'));
+	await page.getByTestId('submit-request').click();
+	await responsePromise;
+
+	// Wait for success state with the request link
+	await expect(page.getByTestId('request-link')).toBeVisible({ timeout: 15000 });
+	requestLink = (await page.getByTestId('request-link').textContent())?.trim() ?? '';
+	expect(requestLink).toContain('/r/');
+
+	// Extract receipt ID from success message
+	const successMessage = (await page.getByTestId('request-success-message').textContent()) ?? '';
+	const receiptMatch = successMessage.match(/receipt code is:\s*(\w+)/i);
+	expect(receiptMatch).toBeTruthy();
+	receiptId = receiptMatch![1];
+});
+
+test('Response page shows note and accepts response', async () => {
+	// Open the request link
+	await page.goto(requestLink);
+	await page.waitForLoadState('networkidle');
+
+	// Verify the decrypted note is visible
+	await expect(page.getByTestId('decrypted-note')).toBeVisible({ timeout: 10000 });
+	await expect(page.getByTestId('decrypted-note')).toContainText(noteText);
+
+	// Fill in the response
+	await page.getByTestId('input-response-content').fill(responseText);
+
+	// Submit the response
+	const responsePromise = page.waitForResponse((r) => r.url().includes('/r/'));
+	await page.getByTestId('submit-response').click();
+	await responsePromise;
+
+	// Verify success
+	await expect(page.getByTestId('response-success')).toBeVisible({ timeout: 15000 });
+});
+
+test('Requests list shows unread item with matching receipt ID', async () => {
+	await page.goto('/account/requests');
+	await page.waitForLoadState('networkidle');
+
+	// Wait for the table to load
+	await expect(page.getByTestId('request-receipt-id').first()).toBeVisible({ timeout: 15000 });
+
+	// Find the row with our receipt ID
+	const receiptCells = page.getByTestId('request-receipt-id');
+	const count = await receiptCells.count();
+
+	let found = false;
+	for (let i = 0; i < count; i++) {
+		const text = await receiptCells.nth(i).textContent();
+		if (text?.trim() === receiptId) {
+			// Verify the status in the same row is "Unread"
+			const row = receiptCells.nth(i).locator('xpath=ancestor::tr');
+			const status = row.getByTestId('request-status-label');
+			await expect(status).toContainText('Unread');
+			found = true;
+			break;
+		}
+	}
+
+	expect(found).toBe(true);
+});
+
+test('View response and verify decrypted content', async () => {
+	// Click the first "View" button (most recent request)
+	await page.getByTestId('view-response').first().click();
+
+	// Wait for decryption and verify the response content
+	await expect(page.getByTestId('decrypted-response')).toBeVisible({ timeout: 15000 });
+	await expect(page.getByTestId('decrypted-response')).toContainText(responseText);
+});

--- a/src/lib/components/blocks/create-secret-request.svelte
+++ b/src/lib/components/blocks/create-secret-request.svelte
@@ -47,8 +47,10 @@
 				{m.proud_vivid_hawk_cheer()}
 			</h3>
 			<div class="min-w-0 shrink overflow-hidden pe-2">
-				<div class="mb-2 truncate text-lg font-normal">{requestLink}</div>
-				<div class="text-muted-foreground block text-sm">
+				<div class="mb-2 truncate text-lg font-normal" data-testid="request-link">
+					{requestLink}
+				</div>
+				<div class="text-muted-foreground block text-sm" data-testid="request-success-message">
 					<Markdown markdown={successMessage} />
 				</div>
 			</div>

--- a/src/lib/components/forms/secret-request-form.svelte
+++ b/src/lib/components/forms/secret-request-form.svelte
@@ -162,6 +162,7 @@
 		<Form.Field form={sForm} name="encryptedNote">
 			<Textarea
 				bind:value={noteText}
+				data-testid="input-request-note"
 				label={m.soft_kind_swan_write()}
 				placeholder={m.pale_quick_finch_hint()}
 				rows={4}
@@ -193,8 +194,11 @@
 				>{isOptionsVisible ? m.teal_wide_owl_arise() : m.main_direct_salmon_savor()}
 				<ChevronDown class="ml-2 h-4 w-4 {isOptionsVisible ? 'rotate-180' : ''}" /></Toggle
 			>
-			<Form.Button class="sm:ml-auto" delayed={$delayed} disabled={!keysReady}
-				>{m.keen_bold_falcon_send()}</Form.Button
+			<Form.Button
+				class="sm:ml-auto"
+				delayed={$delayed}
+				disabled={!keysReady}
+				data-testid="submit-request">{m.keen_bold_falcon_send()}</Form.Button
 			>
 		</div>
 	</form>

--- a/src/lib/components/forms/secret-response-form.svelte
+++ b/src/lib/components/forms/secret-response-form.svelte
@@ -115,12 +115,15 @@
 		<Form.Field form={sForm} name="encryptedResponseContent">
 			<Textarea
 				bind:value={responseText}
+				data-testid="input-response-content"
 				label={m.neat_shy_mole_type()}
 				placeholder={m.pale_soft_wren_hint()}
 				rows={6}
 			/>
 		</Form.Field>
 
-		<Form.Button delayed={$delayed}>{m.bold_true_ram_send()}</Form.Button>
+		<Form.Button delayed={$delayed} data-testid="submit-response"
+			>{m.bold_true_ram_send()}</Form.Button
+		>
 	</form>
 </FormWrapper>

--- a/src/routes/(app)/(default)/account/requests-card.svelte
+++ b/src/routes/(app)/(default)/account/requests-card.svelte
@@ -122,7 +122,9 @@
 					{@const config = statusConfig[request.status]}
 					<Table.Row>
 						<Table.Cell class="font-medium">
-							<span class="inline-block p-1 font-mono">{request.receiptId ?? '—'}</span>
+							<span class="inline-block p-1 font-mono" data-testid="request-receipt-id"
+								>{request.receiptId ?? '—'}</span
+							>
 						</Table.Cell>
 						<Table.Cell>
 							{#if decryptedNotes[request.id]}
@@ -143,9 +145,12 @@
 						<Table.Cell>
 							<Tooltip.Root>
 								<Tooltip.Trigger>
-									<div class="inline-flex items-center gap-1.5 whitespace-nowrap {config.class}">
+									<div
+										class="inline-flex items-center gap-1.5 whitespace-nowrap {config.class}"
+										data-testid="request-status"
+									>
 										<config.icon class="h-4 w-4 shrink-0" />
-										<span>{config.label}</span>
+										<span data-testid="request-status-label">{config.label}</span>
 									</div>
 								</Tooltip.Trigger>
 								<Tooltip.Content class="text-left">
@@ -168,6 +173,7 @@
 										size="sm"
 										variant="outline"
 										href={localizeHref(`/account/requests/${request.id}`)}
+										data-testid="view-response"
 									>
 										<Eye class="mr-1.5 h-3.5 w-3.5" />
 										{m.keen_bright_fox_peek()}

--- a/src/routes/(app)/(default)/account/requests/[id]/+page.svelte
+++ b/src/routes/(app)/(default)/account/requests/[id]/+page.svelte
@@ -85,7 +85,7 @@
 			<p class="text-muted-foreground">{m.slow_calm_newt_spin()}</p>
 		</div>
 	{:else if decryptedResponse}
-		<div class="bg-muted rounded-lg p-4">
+		<div class="bg-muted rounded-lg p-4" data-testid="decrypted-response">
 			<pre class="font-mono text-sm break-words whitespace-pre-wrap">{decryptedResponse}</pre>
 		</div>
 		<div class="mt-4 flex justify-end gap-2">

--- a/src/routes/(app)/(default)/r/[requestIdHash]/+page.svelte
+++ b/src/routes/(app)/(default)/r/[requestIdHash]/+page.svelte
@@ -54,6 +54,7 @@
 			<div
 				in:fade
 				class="border-primary bg-card relative mb-2 flex min-h-[200px] w-full flex-col items-center justify-center overflow-hidden rounded border px-4 py-6 shadow-lg md:p-8"
+				data-testid="response-success"
 			>
 				<Check class="text-primary mb-4 h-12 w-12" />
 				<h3 class="text-primary mb-2 text-2xl font-semibold">
@@ -78,7 +79,7 @@
 						{/if}
 					</p>
 					{#if decryptedNote}
-						<p>{decryptedNote}</p>
+						<p data-testid="decrypted-note">{decryptedNote}</p>
 					{/if}
 				</div>
 


### PR DESCRIPTION
## Summary
- Add end-to-end test covering the full secret request flow: login → create request with note → submit response on public page → verify unread status with receipt ID → decrypt and verify response content
- Add `data-testid` attributes to request/response forms, requests card, and detail pages to support test selectors

## Test plan
- [x] Run `pnpm test:e2e` with a local dev server and verify the new `secret-request.test.ts` passes
- [x] Verify existing e2e tests still pass (no regressions from added test IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)