### PR TITLE
fix(cron): switch S3 retention job to per-object deletes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,6 @@ PUBLIC_STRIPE_PUBLISHABLE_KEY=''
 STRIPE_SECRET_KEY=''
 STRIPE_WEBHOOK_SECRET=''
 
-# Only for local development (translations)
-GEMINI_API_KEY=''
-
 # E2E test credentials
 # Be aware. Need for Github Actions.
 E2E_USER_EMAIL=''

--- a/src/routes/api/v1/cron/+server.ts
+++ b/src/routes/api/v1/cron/+server.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectsCommand, paginateListObjectsV2 } from '@aws-sdk/client-s3';
+import { DeleteObjectCommand, paginateListObjectsV2 } from '@aws-sdk/client-s3';
 import type { RequestHandler } from '@sveltejs/kit';
 import { error, json } from '@sveltejs/kit';
 import { eq, or } from 'drizzle-orm';
@@ -50,24 +50,18 @@ export const GET: RequestHandler = async ({ request }) => {
 				}
 			}).filter(Boolean) as ObjectList;
 
-			// @todo
-			// We currently get an error for no obvious reason
-			// InvalidDigest: The Content-MD5 you specified was an invalid
-			// We catch the error for now
-			try {
-				if (s3ObjectsToDelete.length) {
-					console.log(`Cron: Start deleting files...`);
-					const bucketParams = {
-						Bucket: BucketName,
-						Delete: { Objects: s3ObjectsToDelete, Quiet: false }
-					};
-					await client.send(new DeleteObjectsCommand(bucketParams));
-					console.log(`Cron: Deleted ${s3ObjectsToDelete.length} files from S3.`);
-				} else {
-					console.log(`Cron: No files to delete from S3.`);
-				}
-			} catch (e) {
-				console.error(e);
+			if (s3ObjectsToDelete.length) {
+				console.log(`Cron: Start deleting files...`);
+				// Using per-object DeleteObjectCommand instead of batch DeleteObjectsCommand:
+				// flow.swiss rejects the checksum header that AWS SDK v3 attaches to the batch op.
+				await Promise.all(
+					s3ObjectsToDelete.map(({ Key }) =>
+						client.send(new DeleteObjectCommand({ Bucket: BucketName, Key }))
+					)
+				);
+				console.log(`Cron: Deleted ${s3ObjectsToDelete.length} files from S3.`);
+			} else {
+				console.log(`Cron: No files to delete from S3.`);
 			}
 		}
 


### PR DESCRIPTION
## Summary
- The nightly retention cron has been silently failing to delete old S3 files — the batch `DeleteObjectsCommand` was wrapped in a try/catch swallowing an `InvalidDigest: The Content-MD5 you specified was an invalid` error.
- Root cause: AWS SDK v3 attaches a checksum header to the batch `DeleteObjects` request that flow.swiss (the S3-compatible backend) rejects.
- Fix: use per-object `DeleteObjectCommand` in parallel — single-object delete doesn't require a checksum.
- Also removes the try/catch so future failures surface in Vercel cron logs instead of being swallowed.

## Test plan
- [x] Reproduced the `InvalidDigest` error locally against flow.swiss
- [x] Confirmed the per-object delete path succeeds locally
- [ ] After merge: watch the next nightly cron run (01:00 UTC) — expect `Cron: Deleted N files from S3.` and no stack trace
- [ ] Verify old files in the bucket start dropping off per the `FILE_RETENTION_PERIOD_IN_DAYS` policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)