### PR TITLE
feat(cli-page): add /cli page with GFM tables and dark mode code highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 		"postgres": "^3.4.5",
 		"pretty-bytes": "^6.1.1",
 		"rehype-highlight": "^7.0.2",
+		"remark-gfm": "^4.0.1",
 		"resend": "^4.1.1",
 		"runed": "^0.23.3",
 		"stripe": "^17.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       rehype-highlight:
         specifier: ^7.0.2
         version: 7.0.2
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       resend:
         specifier: ^4.1.1
         version: 4.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)

--- a/src/app.css
+++ b/src/app.css
@@ -158,22 +158,33 @@
 }
 
 @utility prose {
-	--tw-prose-body: hsl(var(--foreground));
-	--tw-prose-headings: hsl(var(--foreground));
-	--tw-prose-lead: hsl(var(--foreground));
-	--tw-prose-links: hsl(var(--foreground));
+	--tw-prose-body: var(--color-foreground);
+	--tw-prose-headings: var(--color-foreground);
+	--tw-prose-lead: var(--color-foreground);
+	--tw-prose-links: var(--color-foreground);
 
-	--tw-prose-bold: hsl(var(--foreground));
-	--tw-prose-counters: hsl(var(--foreground));
-	--tw-prose-bullets: hsl(var(--border));
-	--tw-prose-hr: hsl(var(--border));
-	--tw-prose-quotes: hsl(var(--muted-foreground));
-	--tw-prose-quote-borders: hsl(var(--border));
-	--tw-prose-captions: hsl(var(--muted-foreground));
+	--tw-prose-bold: var(--color-foreground);
+	--tw-prose-counters: var(--color-foreground);
+	--tw-prose-bullets: var(--color-border);
+	--tw-prose-hr: var(--color-border);
+	--tw-prose-quotes: var(--color-muted-foreground);
+	--tw-prose-quote-borders: var(--color-border);
+	--tw-prose-captions: var(--color-muted-foreground);
 
-	--tw-prose-code: hsl(var(--foreground));
-	--tw-prose-pre-code: hsl(var(--foreground));
-	--tw-prose-pre-bg: hsl(var(--muted));
-	--tw-prose-th-borders: hsl(var(--border));
-	--tw-prose-td-borders: hsl(var(--border));
+	--tw-prose-code: var(--color-foreground);
+	--tw-prose-pre-code: var(--color-foreground);
+	--tw-prose-pre-bg: var(--color-muted);
+	--tw-prose-th-borders: var(--color-border);
+	--tw-prose-td-borders: var(--color-border);
+
+	& code::before,
+	& code::after {
+		content: none;
+	}
+
+	& code {
+		background-color: var(--color-muted);
+		padding: 2px 5px;
+		border-radius: 5px;
+	}
 }

--- a/src/app.css
+++ b/src/app.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import '$lib/components/ui/markdown/highlight.css';
 @plugin '@tailwindcss/typography';
 
 @custom-variant dark (&:where(.dark, .dark *));

--- a/src/lib/components/ui/markdown/highlight.css
+++ b/src/lib/components/ui/markdown/highlight.css
@@ -1,0 +1,165 @@
+/* highlight.js — GitHub light theme (default) */
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+.hljs {
+  color: #24292e;
+  background: #ffffff;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  color: #d73a49;
+}
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  color: #6f42c1;
+}
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  color: #005cc5;
+}
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  color: #032f62;
+}
+.hljs-built_in,
+.hljs-symbol {
+  color: #e36209;
+}
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  color: #6a737d;
+}
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  color: #22863a;
+}
+.hljs-subst {
+  color: #24292e;
+}
+.hljs-section {
+  color: #005cc5;
+  font-weight: bold;
+}
+.hljs-bullet {
+  color: #735c0f;
+}
+.hljs-emphasis {
+  color: #24292e;
+  font-style: italic;
+}
+.hljs-strong {
+  color: #24292e;
+  font-weight: bold;
+}
+.hljs-addition {
+  color: #22863a;
+  background-color: #f0fff4;
+}
+.hljs-deletion {
+  color: #b31d28;
+  background-color: #ffeef0;
+}
+
+/* highlight.js — GitHub dark theme */
+.dark .hljs {
+  color: #c9d1d9;
+  background: #0d1117;
+}
+.dark .hljs-doctag,
+.dark .hljs-keyword,
+.dark .hljs-meta .hljs-keyword,
+.dark .hljs-template-tag,
+.dark .hljs-template-variable,
+.dark .hljs-type,
+.dark .hljs-variable.language_ {
+  color: #ff7b72;
+}
+.dark .hljs-title,
+.dark .hljs-title.class_,
+.dark .hljs-title.class_.inherited__,
+.dark .hljs-title.function_ {
+  color: #d2a8ff;
+}
+.dark .hljs-attr,
+.dark .hljs-attribute,
+.dark .hljs-literal,
+.dark .hljs-meta,
+.dark .hljs-number,
+.dark .hljs-operator,
+.dark .hljs-variable,
+.dark .hljs-selector-attr,
+.dark .hljs-selector-class,
+.dark .hljs-selector-id {
+  color: #79c0ff;
+}
+.dark .hljs-regexp,
+.dark .hljs-string,
+.dark .hljs-meta .hljs-string {
+  color: #a5d6ff;
+}
+.dark .hljs-built_in,
+.dark .hljs-symbol {
+  color: #ffa657;
+}
+.dark .hljs-comment,
+.dark .hljs-code,
+.dark .hljs-formula {
+  color: #8b949e;
+}
+.dark .hljs-name,
+.dark .hljs-quote,
+.dark .hljs-selector-tag,
+.dark .hljs-selector-pseudo {
+  color: #7ee787;
+}
+.dark .hljs-subst {
+  color: #c9d1d9;
+}
+.dark .hljs-section {
+  color: #1f6feb;
+  font-weight: bold;
+}
+.dark .hljs-bullet {
+  color: #f2cc60;
+}
+.dark .hljs-emphasis {
+  color: #c9d1d9;
+  font-style: italic;
+}
+.dark .hljs-strong {
+  color: #c9d1d9;
+  font-weight: bold;
+}
+.dark .hljs-addition {
+  color: #aff5b4;
+  background-color: #033a16;
+}
+.dark .hljs-deletion {
+  color: #ffdcd7;
+  background-color: #67060c;
+}

--- a/src/lib/components/ui/markdown/highlight.css
+++ b/src/lib/components/ui/markdown/highlight.css
@@ -1,15 +1,15 @@
 /* highlight.js — GitHub light theme (default) */
 pre code.hljs {
-  display: block;
-  overflow-x: auto;
-  padding: 1em;
+	display: block;
+	overflow-x: auto;
+	padding: 1em;
 }
 code.hljs {
-  padding: 3px 5px;
+	padding: 3px 5px;
 }
 .hljs {
-  color: #24292e;
-  background: #ffffff;
+	color: #24292e;
+	background: #ffffff;
 }
 .hljs-doctag,
 .hljs-keyword,
@@ -18,13 +18,13 @@ code.hljs {
 .hljs-template-variable,
 .hljs-type,
 .hljs-variable.language_ {
-  color: #d73a49;
+	color: #d73a49;
 }
 .hljs-title,
 .hljs-title.class_,
 .hljs-title.class_.inherited__,
 .hljs-title.function_ {
-  color: #6f42c1;
+	color: #6f42c1;
 }
 .hljs-attr,
 .hljs-attribute,
@@ -36,59 +36,59 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-selector-class,
 .hljs-selector-id {
-  color: #005cc5;
+	color: #005cc5;
 }
 .hljs-regexp,
 .hljs-string,
 .hljs-meta .hljs-string {
-  color: #032f62;
+	color: #032f62;
 }
 .hljs-built_in,
 .hljs-symbol {
-  color: #e36209;
+	color: #e36209;
 }
 .hljs-comment,
 .hljs-code,
 .hljs-formula {
-  color: #6a737d;
+	color: #6a737d;
 }
 .hljs-name,
 .hljs-quote,
 .hljs-selector-tag,
 .hljs-selector-pseudo {
-  color: #22863a;
+	color: #22863a;
 }
 .hljs-subst {
-  color: #24292e;
+	color: #24292e;
 }
 .hljs-section {
-  color: #005cc5;
-  font-weight: bold;
+	color: #005cc5;
+	font-weight: bold;
 }
 .hljs-bullet {
-  color: #735c0f;
+	color: #735c0f;
 }
 .hljs-emphasis {
-  color: #24292e;
-  font-style: italic;
+	color: #24292e;
+	font-style: italic;
 }
 .hljs-strong {
-  color: #24292e;
-  font-weight: bold;
+	color: #24292e;
+	font-weight: bold;
 }
 .hljs-addition {
-  color: #22863a;
-  background-color: #f0fff4;
+	color: #22863a;
+	background-color: #f0fff4;
 }
 .hljs-deletion {
-  color: #b31d28;
-  background-color: #ffeef0;
+	color: #b31d28;
+	background-color: #ffeef0;
 }
 
 /* highlight.js — GitHub dark theme */
 .dark .hljs {
-  color: #c9d1d9;
-  background: #0d1117;
+	color: #c9d1d9;
+	background: #0d1117;
 }
 .dark .hljs-doctag,
 .dark .hljs-keyword,
@@ -97,13 +97,13 @@ code.hljs {
 .dark .hljs-template-variable,
 .dark .hljs-type,
 .dark .hljs-variable.language_ {
-  color: #ff7b72;
+	color: #ff7b72;
 }
 .dark .hljs-title,
 .dark .hljs-title.class_,
 .dark .hljs-title.class_.inherited__,
 .dark .hljs-title.function_ {
-  color: #d2a8ff;
+	color: #d2a8ff;
 }
 .dark .hljs-attr,
 .dark .hljs-attribute,
@@ -115,51 +115,51 @@ code.hljs {
 .dark .hljs-selector-attr,
 .dark .hljs-selector-class,
 .dark .hljs-selector-id {
-  color: #79c0ff;
+	color: #79c0ff;
 }
 .dark .hljs-regexp,
 .dark .hljs-string,
 .dark .hljs-meta .hljs-string {
-  color: #a5d6ff;
+	color: #a5d6ff;
 }
 .dark .hljs-built_in,
 .dark .hljs-symbol {
-  color: #ffa657;
+	color: #ffa657;
 }
 .dark .hljs-comment,
 .dark .hljs-code,
 .dark .hljs-formula {
-  color: #8b949e;
+	color: #8b949e;
 }
 .dark .hljs-name,
 .dark .hljs-quote,
 .dark .hljs-selector-tag,
 .dark .hljs-selector-pseudo {
-  color: #7ee787;
+	color: #7ee787;
 }
 .dark .hljs-subst {
-  color: #c9d1d9;
+	color: #c9d1d9;
 }
 .dark .hljs-section {
-  color: #1f6feb;
-  font-weight: bold;
+	color: #1f6feb;
+	font-weight: bold;
 }
 .dark .hljs-bullet {
-  color: #f2cc60;
+	color: #f2cc60;
 }
 .dark .hljs-emphasis {
-  color: #c9d1d9;
-  font-style: italic;
+	color: #c9d1d9;
+	font-style: italic;
 }
 .dark .hljs-strong {
-  color: #c9d1d9;
-  font-weight: bold;
+	color: #c9d1d9;
+	font-weight: bold;
 }
 .dark .hljs-addition {
-  color: #aff5b4;
-  background-color: #033a16;
+	color: #aff5b4;
+	background-color: #033a16;
 }
 .dark .hljs-deletion {
-  color: #ffdcd7;
-  background-color: #67060c;
+	color: #ffdcd7;
+	background-color: #67060c;
 }

--- a/src/lib/components/ui/markdown/markdown.svelte
+++ b/src/lib/components/ui/markdown/markdown.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-	import 'highlight.js/styles/github.css';
-
 	import rehypeHighlight from 'rehype-highlight';
+	import remarkGfm from 'remark-gfm';
 	import type { Plugin } from 'svelte-exmarkdown';
 	import SvelteMarkdown from 'svelte-exmarkdown';
 
+	const gfmPlugin: Plugin = { remarkPlugin: [remarkGfm] };
+
 	const plugins: Plugin[] = [
+		gfmPlugin,
 		{
 			rehypePlugin: [rehypeHighlight, { ignoreMissing: true }]
 		}
@@ -20,5 +22,12 @@
 </script>
 
 <span class={format ? 'prose' : 'hover:[&_a]:text-primary [&_a]:underline'}>
-	<SvelteMarkdown md={markdown} plugins={formatCode ? plugins : undefined} />
+	<SvelteMarkdown md={markdown} plugins={formatCode ? plugins : [gfmPlugin]} />
 </span>
+
+<style>
+	:global(.prose > pre) {
+		padding: 0;
+		border: 1px solid var(--color-border);
+	}
+</style>

--- a/src/lib/data/docs/cli.md
+++ b/src/lib/data/docs/cli.md
@@ -26,15 +26,15 @@ scrtlink <secret> [options]
 
 ### Options
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--type` | `text` \| `redirect` \| `neogram` | `text` |
-| `--expires` | `1h` \| `1d` \| `1w` \| `1m` | `1w` |
-| `--views` | View limit 1–1000 | `1` |
-| `--note` | Public note shown to recipient before reveal | — |
-| `--password` | Password-protect the secret | — |
-| `--host` | Override API host (white-label instances) | `scrt.link` |
-| `--api-key` | API key — overrides `SCRT_LINK_API_KEY` env var | — |
+| Flag         | Description                                     | Default     |
+| ------------ | ----------------------------------------------- | ----------- |
+| `--type`     | `text` \| `redirect` \| `neogram`               | `text`      |
+| `--expires`  | `1h` \| `1d` \| `1w` \| `1m`                    | `1w`        |
+| `--views`    | View limit 1–1000                               | `1`         |
+| `--note`     | Public note shown to recipient before reveal    | —           |
+| `--password` | Password-protect the secret                     | —           |
+| `--host`     | Override API host (white-label instances)       | `scrt.link` |
+| `--api-key`  | API key — overrides `SCRT_LINK_API_KEY` env var | —           |
 
 ### Examples
 
@@ -67,7 +67,7 @@ Or pass it inline for a single command:
 scrtlink "my secret" --api-key ak_...
 ```
 
-## Self-hosted / White-label
+## White-label
 
 Point the CLI at your own scrt.link instance with `--host`:
 
@@ -77,8 +77,8 @@ scrtlink "my secret" --host yourdomain.com
 
 ## Secret Types
 
-| Type | Description |
-|------|-------------|
-| `text` | Plain text secret (default) |
-| `redirect` | A URL — recipient is redirected after reveal |
-| `neogram` | Self-destructing message with animated reveal |
+| Type       | Description                                   |
+| ---------- | --------------------------------------------- |
+| `text`     | Plain text secret (default)                   |
+| `redirect` | A URL — recipient is redirected after reveal  |
+| `neogram`  | Self-destructing message with animated reveal |

--- a/src/lib/data/docs/cli.md
+++ b/src/lib/data/docs/cli.md
@@ -1,0 +1,84 @@
+Create end-to-end encrypted secrets directly from your terminal. The `scrtlink` CLI is built on top of the [scrt.link API](/api-documentation) and uses the same client-side encryption as the web app — the server never sees your plaintext.
+
+To use the CLI, you'll need an active [subscription](/pricing) and an API key from your [account page](/account/api).
+
+## Installation
+
+```bash
+npm install -g @scrt-link/cli
+```
+
+## Quick Start
+
+```bash
+# Set your API key once
+export SCRT_LINK_API_KEY=ak_...
+
+# Create a secret — prints the link to stdout
+scrtlink "super-secret-password"
+```
+
+## Usage
+
+```bash
+scrtlink <secret> [options]
+```
+
+### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--type` | `text` \| `redirect` \| `neogram` | `text` |
+| `--expires` | `1h` \| `1d` \| `1w` \| `1m` | `1w` |
+| `--views` | View limit 1–1000 | `1` |
+| `--note` | Public note shown to recipient before reveal | — |
+| `--password` | Password-protect the secret | — |
+| `--host` | Override API host (white-label instances) | `scrt.link` |
+| `--api-key` | API key — overrides `SCRT_LINK_API_KEY` env var | — |
+
+### Examples
+
+```bash
+# Redirect secret that expires in 1 hour
+scrtlink "https://example.com" --type redirect --expires 1h
+
+# Password-protected secret, viewable up to 5 times
+scrtlink "my secret" --password "unlock123" --views 5
+
+# Add a note the recipient sees before revealing
+scrtlink "my secret" --note "Your one-time credentials"
+
+# Pipe the link directly to clipboard (macOS)
+scrtlink "my secret" | pbcopy
+```
+
+## API Key
+
+Set the `SCRT_LINK_API_KEY` environment variable to avoid passing `--api-key` on every command:
+
+```bash
+# Add to your shell profile (~/.zshrc, ~/.bashrc, etc.)
+export SCRT_LINK_API_KEY=ak_...
+```
+
+Or pass it inline for a single command:
+
+```bash
+scrtlink "my secret" --api-key ak_...
+```
+
+## Self-hosted / White-label
+
+Point the CLI at your own scrt.link instance with `--host`:
+
+```bash
+scrtlink "my secret" --host yourdomain.com
+```
+
+## Secret Types
+
+| Type | Description |
+|------|-------------|
+| `text` | Plain text secret (default) |
+| `redirect` | A URL — recipient is redirected after reveal |
+| `neogram` | Self-destructing message with animated reveal |

--- a/src/lib/data/menu.ts
+++ b/src/lib/data/menu.ts
@@ -56,7 +56,11 @@ export const productMenu = () => [
 	},
 	{
 		href: '/api-documentation',
-		label: m.salty_sea_insect_fry()
+		label: 'API Docs'
+	},
+	{
+		href: '/cli',
+		label: 'CLI'
 	},
 	{
 		href: 'https://deepwiki.com/stophecom/scrt-link-v2',

--- a/src/routes/(app)/(default)/cli/+page.svelte
+++ b/src/routes/(app)/(default)/cli/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import Page from '$lib/components/page/default-page.svelte';
+	import Container from '$lib/components/ui/container/container.svelte';
+	import Markdown from '$lib/components/ui/markdown';
+	import cliDocs from '$lib/data/docs/cli.md?raw';
+</script>
+
+<Page wide title="CLI" lead="Create encrypted secrets from the command line." markNotTranslated>
+	<Container variant="wide">
+		<Markdown markdown={cliDocs} format={true} formatCode />
+	</Container>
+</Page>

--- a/src/routes/white-label/[domain]/header.svelte
+++ b/src/routes/white-label/[domain]/header.svelte
@@ -26,7 +26,7 @@
 	let logoSrc = $derived(mode.current === 'dark' ? logoDarkMode : logo);
 </script>
 
-<header class="bg-background shadow-sm" {...rest}>
+<header class="bg-card shadow-sm" {...rest}>
 	<Container class="flex justify-between py-2" variant={wide ? 'wide' : 'default'}>
 		<a class="inline-flex h-12 w-36 items-center" href={localizeHref('/')}>
 			{#if logoSrc}


### PR DESCRIPTION
## Summary

- Add `/cli` documentation page with usage, options, and examples
- Fix markdown table rendering by adding `remark-gfm` plugin to the Markdown component
- Add dark mode support for `highlight.js` code highlighting — extracted styles into a dedicated `highlight.css` imported globally via `app.css`

## Test plan

- [ ] Visit `/cli` and verify tables render correctly in light and dark mode
- [ ] Verify code blocks have syntax highlighting in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)