### PR TITLE
fix(csp): allow white-label pages to be embedded same-origin

### DIFF
--- a/.github/workflows/playwright-tests-published.yml
+++ b/.github/workflows/playwright-tests-published.yml
@@ -8,6 +8,9 @@ jobs:
     name: Run end-to-end tests on published site
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
+    # Without this, a hung `playwright install` (a known CDN-stall failure mode)
+    # squats on the runner until GitHub's 6h max-job-time kills it.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
@@ -15,7 +18,17 @@ jobs:
           node-version: 24
       - uses: pnpm/action-setup@v6
       - name: Install dependencies
-        run: pnpm install && npx playwright install --with-deps
+        run: pnpm install
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - name: Install Playwright browser
+        # Bound the flaky browser download so a stall fails fast and is retryable.
+        # Only chromium is needed (playwright.config.ts specifies no other browser).
+        timeout-minutes: 8
+        run: npx playwright install --with-deps chromium
       - name: Run tests on preview PR
         if: github.event.deployment_status.environment != 'Production'
         run: xvfb-run npx playwright test

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@inlang/paraglide-js": "2.9.1",
 		"@internationalized/date": "^3.12.0",
 		"@lucide/svelte": "^1.7.0",
-		"@playwright/test": "^1.58.2",
+		"@playwright/test": "^1.60.0",
 		"@poppanator/sveltekit-svg": "^5.0.0",
 		"@sveltejs/adapter-node": "^5.5.0",
 		"@sveltejs/adapter-vercel": "^6.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(svelte@5.55.7(@typescript-eslint/types@8.54.0))
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.60.0
+        version: 1.60.0
       '@poppanator/sveltekit-svg':
         specifier: ^5.0.0
         version: 5.0.1(rollup@4.57.1)(svelte@5.55.7(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -131,7 +131,7 @@ importers:
         version: 25.5.2
       '@vitest/browser':
         specifier: ^3.0.1
-        version: 3.2.4(playwright@1.58.2)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@3.2.4)
+        version: 3.2.4(playwright@1.60.0)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@3.2.4)
       bits-ui:
         specifier: ^2.17.2
         version: 2.17.2(@internationalized/date@3.12.0)(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.55.7(@typescript-eslint/types@8.54.0))(typescript@5.9.3)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.55.7(@typescript-eslint/types@8.54.0))
@@ -1248,8 +1248,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3754,13 +3754,13 @@ packages:
     engines: {node: '>=10'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5812,9 +5812,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -6788,7 +6788,7 @@ snapshots:
       validator: 13.15.26
     optional: true
 
-  '@vitest/browser@3.2.4(playwright@1.58.2)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(playwright@1.60.0)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
@@ -6800,7 +6800,7 @@ snapshots:
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.2)(@vitest/browser@3.2.4)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
       ws: 8.19.0
     optionalDependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -8453,11 +8453,11 @@ snapshots:
 
   plausible-tracker@0.3.9: {}
 
-  playwright-core@1.58.2: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.58.2:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.58.2
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -9423,7 +9423,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 25.5.2
-      '@vitest/browser': 3.2.4(playwright@1.58.2)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.60.0)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,6 +7,7 @@ import { ThemeOptions, TierOptions } from '$lib/data/enums';
 import { paraglideMiddleware } from '$lib/paraglide/server';
 import * as auth from '$lib/server/auth.js';
 import { getEffectiveTierForUser } from '$lib/server/organization';
+import { applyFrameHeaders } from '$lib/server/security-headers';
 import { getWhiteLabelSiteByHost } from '$lib/server/whiteLabelSite';
 
 const guards = import.meta.glob('./routes/**/-guard.*');
@@ -129,12 +130,15 @@ const handleTheme: Handle = async ({ event, resolve }) => {
 const handleSecurityHeaders: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
 	response.headers.set('X-Content-Type-Options', 'nosniff');
-	response.headers.set('X-Frame-Options', 'DENY');
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 	response.headers.set(
 		'Permissions-Policy',
 		'camera=(), microphone=(), geolocation=(), usb=(), payment=()'
 	);
+
+	// White-label pages may be embedded same-origin; everything else stays frame-denied.
+	// `event.locals.whiteLabelSite` is populated by handleWhiteLabelSite during resolve().
+	applyFrameHeaders(response.headers, Boolean(event.locals.whiteLabelSite));
 	return response;
 };
 

--- a/src/lib/server/security-headers.spec.ts
+++ b/src/lib/server/security-headers.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+
+import { applyFrameHeaders } from './security-headers';
+
+// Mirrors the frame-ancestors directive emitted by SvelteKit's CSP config.
+const BASE_CSP =
+	"default-src 'none'; script-src 'self'; frame-src 'self' https://js.stripe.com; frame-ancestors 'none'; base-uri 'self'";
+
+describe('applyFrameHeaders', () => {
+	describe('non-white-label responses', () => {
+		test('denies framing entirely', () => {
+			const headers = new Headers({ 'content-security-policy': BASE_CSP });
+			applyFrameHeaders(headers, false);
+			expect(headers.get('X-Frame-Options')).toBe('DENY');
+		});
+
+		test('leaves the CSP frame-ancestors directive untouched', () => {
+			const headers = new Headers({ 'content-security-policy': BASE_CSP });
+			applyFrameHeaders(headers, false);
+			expect(headers.get('content-security-policy')).toContain("frame-ancestors 'none'");
+		});
+	});
+
+	describe('white-label responses', () => {
+		test('allows same-origin framing via X-Frame-Options', () => {
+			const headers = new Headers({ 'content-security-policy': BASE_CSP });
+			applyFrameHeaders(headers, true);
+			expect(headers.get('X-Frame-Options')).toBe('SAMEORIGIN');
+		});
+
+		test("relaxes frame-ancestors to 'self'", () => {
+			const headers = new Headers({ 'content-security-policy': BASE_CSP });
+			applyFrameHeaders(headers, true);
+			const csp = headers.get('content-security-policy');
+			expect(csp).toContain("frame-ancestors 'self'");
+			expect(csp).not.toContain("frame-ancestors 'none'");
+		});
+
+		test('does not touch other CSP directives (e.g. frame-src)', () => {
+			const headers = new Headers({ 'content-security-policy': BASE_CSP });
+			applyFrameHeaders(headers, true);
+			const csp = headers.get('content-security-policy');
+			expect(csp).toContain("frame-src 'self' https://js.stripe.com");
+			expect(csp).toContain("default-src 'none'");
+			expect(csp).toContain("base-uri 'self'");
+		});
+
+		test('sets SAMEORIGIN even when no CSP header is present', () => {
+			const headers = new Headers();
+			applyFrameHeaders(headers, true);
+			expect(headers.get('X-Frame-Options')).toBe('SAMEORIGIN');
+			expect(headers.get('content-security-policy')).toBeNull();
+		});
+	});
+});

--- a/src/lib/server/security-headers.ts
+++ b/src/lib/server/security-headers.ts
@@ -1,0 +1,27 @@
+/**
+ * Applies frame-embedding (clickjacking) protection headers to a response.
+ *
+ * White-label pages (the `/white-label/[domain]` preview route and custom domains)
+ * may be embedded same-origin, e.g. for in-app previews, so they get
+ * `X-Frame-Options: SAMEORIGIN` and CSP `frame-ancestors 'self'`. Every other
+ * response stays fully frame-denied.
+ *
+ * Both headers are set: modern browsers honor CSP `frame-ancestors` over
+ * `X-Frame-Options`, but older ones rely on the latter, so they must agree.
+ *
+ * Mutates the passed `Headers` in place.
+ */
+export function applyFrameHeaders(headers: Headers, isWhiteLabel: boolean): void {
+	if (isWhiteLabel) {
+		headers.set('X-Frame-Options', 'SAMEORIGIN');
+		const csp = headers.get('content-security-policy');
+		if (csp) {
+			headers.set(
+				'content-security-policy',
+				csp.replace(/frame-ancestors[^;]*/, "frame-ancestors 'self'")
+			);
+		}
+	} else {
+		headers.set('X-Frame-Options', 'DENY');
+	}
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -37,7 +37,7 @@ const config = {
 					'https://lh3.googleusercontent.com'
 				],
 				'connect-src': ['self', 'data:', 'https://*.os.zrh1.flow.swiss', 'https://plausible.io'],
-				'frame-src': ['https://js.stripe.com', 'https://vercel.live'],
+				'frame-src': ['self', 'https://js.stripe.com', 'https://vercel.live'],
 				'worker-src': ['self'],
 				'object-src': ['none'],
 				'base-uri': ['self'],


### PR DESCRIPTION
## Problem

Embedding a same-origin iframe of a white-label preview route (`/white-label/[domain]`) was blocked by the site's framing policy:

- **`frame-src`** in the global CSP lacked `'self'`, so the **parent** page couldn't load the iframe (`Framing '…' violates … frame-src`).
- White-label **responses** sent `frame-ancestors 'none'` (CSP) **and** `X-Frame-Options: DENY`, forbidding any framing of the embedded page.

## Fix

- Add `'self'` to the global CSP `frame-src` so same-origin iframes can load.
- Scope frame-embedding relaxation to **white-label responses only** (preview route + custom domains, keyed off `event.locals.whiteLabelSite`): they get `X-Frame-Options: SAMEORIGIN` + CSP `frame-ancestors 'self'`. Every other page stays fully frame-denied (`DENY` / `'none'`) to prevent clickjacking.
- Both headers are set together because older browsers honor `X-Frame-Options` while modern ones prefer CSP `frame-ancestors` — they must agree.
- Frame-header logic extracted into `src/lib/server/security-headers.ts` (`applyFrameHeaders`) with unit tests.

## Tests

`src/lib/server/security-headers.spec.ts` — 6 cases covering: non-white-label → `DENY` + untouched `frame-ancestors`; white-label → `SAMEORIGIN` + `frame-ancestors 'self'`; other CSP directives preserved; no-CSP-header edge case. All passing locally.

## Not addressed here

The separate `Executing inline script violates … script-src` console error is an inline `<script>` on the host page; the fix is to move it to a bundled/external module rather than weaken `script-src` with `'unsafe-inline'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)