### PR TITLE
fix(invite): gate user creation behind explicit acceptance button

### DIFF
--- a/messages/da.json
+++ b/messages/da.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Glemt adgangskode?",
 	"major_noble_snake_drop": "Log ind med Google",
 	"few_blue_wallaby_read": "Fortsæt",
+	"glad_loud_crab_accept": "Accepter invitation",
 	"flat_moving_finch_assure": "Send",
 	"shy_dizzy_jay_embrace": "Send kode igen",
 	"male_ornate_mantis_feel": "Vælg en stærk adgangskode.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Passwort vergessen?",
 	"major_noble_snake_drop": "Mit Google anmelden",
 	"few_blue_wallaby_read": "Weiter",
+	"glad_loud_crab_accept": "Einladung annehmen",
 	"flat_moving_finch_assure": "Absenden",
 	"shy_dizzy_jay_embrace": "Code erneut senden",
 	"male_ornate_mantis_feel": "Wähle ein starkes Passwort.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Forgot password?",
 	"major_noble_snake_drop": "Sign in with Google",
 	"few_blue_wallaby_read": "Continue",
+	"glad_loud_crab_accept": "Accept Invitation",
 	"flat_moving_finch_assure": "Submit",
 	"shy_dizzy_jay_embrace": "Send code again",
 	"male_ornate_mantis_feel": "Choose a strong password.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "¿Olvidaste tu contraseña?",
 	"major_noble_snake_drop": "Iniciar sesión con Google",
 	"few_blue_wallaby_read": "Continuar",
+	"glad_loud_crab_accept": "Aceptar invitación",
 	"flat_moving_finch_assure": "Enviar",
 	"shy_dizzy_jay_embrace": "Enviar código nuevamente",
 	"male_ornate_mantis_feel": "Elige una contraseña segura.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Mot de passe oublié ?",
 	"major_noble_snake_drop": "Se connecter avec Google",
 	"few_blue_wallaby_read": "Continuer",
+	"glad_loud_crab_accept": "Accepter l'invitation",
 	"flat_moving_finch_assure": "Soumettre",
 	"shy_dizzy_jay_embrace": "Renvoyer le code",
 	"male_ornate_mantis_feel": "Choisissez un mot de passe sécurisé.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Password dimenticata?",
 	"major_noble_snake_drop": "Accedi con Google",
 	"few_blue_wallaby_read": "Continua",
+	"glad_loud_crab_accept": "Accetta invito",
 	"flat_moving_finch_assure": "Invia",
 	"shy_dizzy_jay_embrace": "Invia di nuovo il codice",
 	"male_ornate_mantis_feel": "Scegli una password robusta.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "パスワードをお忘れですか？",
 	"major_noble_snake_drop": "Google でサインイン",
 	"few_blue_wallaby_read": "続行",
+	"glad_loud_crab_accept": "招待を承諾する",
 	"flat_moving_finch_assure": "送信",
 	"shy_dizzy_jay_embrace": "コードを再送信",
 	"male_ornate_mantis_feel": "強力なパスワードを選択してください。",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Wachtwoord vergeten?",
 	"major_noble_snake_drop": "Inloggen met Google",
 	"few_blue_wallaby_read": "Doorgaan",
+	"glad_loud_crab_accept": "Uitnodiging accepteren",
 	"flat_moving_finch_assure": "Verzenden",
 	"shy_dizzy_jay_embrace": "Code opnieuw verzenden",
 	"male_ornate_mantis_feel": "Kies een sterk wachtwoord.",

--- a/messages/no.json
+++ b/messages/no.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Glemt passord?",
 	"major_noble_snake_drop": "Logg inn med Google",
 	"few_blue_wallaby_read": "Fortsett",
+	"glad_loud_crab_accept": "Aksepter invitasjon",
 	"flat_moving_finch_assure": "Send inn",
 	"shy_dizzy_jay_embrace": "Send kode på nytt",
 	"male_ornate_mantis_feel": "Velg et sterkt passord.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Nie pamiętasz hasła?",
 	"major_noble_snake_drop": "Zaloguj się przez Google",
 	"few_blue_wallaby_read": "Kontynuuj",
+	"glad_loud_crab_accept": "Zaakceptuj zaproszenie",
 	"flat_moving_finch_assure": "Wyślij",
 	"shy_dizzy_jay_embrace": "Wyślij kod ponownie",
 	"male_ornate_mantis_feel": "Wybierz silne hasło.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Esqueceu a senha?",
 	"major_noble_snake_drop": "Entrar com Google",
 	"few_blue_wallaby_read": "Continuar",
+	"glad_loud_crab_accept": "Aceitar convite",
 	"flat_moving_finch_assure": "Enviar",
 	"shy_dizzy_jay_embrace": "Enviar código novamente",
 	"male_ornate_mantis_feel": "Escolha uma senha forte.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Забыли пароль?",
 	"major_noble_snake_drop": "Войти с Google",
 	"few_blue_wallaby_read": "Продолжить",
+	"glad_loud_crab_accept": "Принять приглашение",
 	"flat_moving_finch_assure": "Отправить",
 	"shy_dizzy_jay_embrace": "Отправить код еще раз",
 	"male_ornate_mantis_feel": "Выберите надежный пароль.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "Glömt lösenordet?",
 	"major_noble_snake_drop": "Logga in med Google",
 	"few_blue_wallaby_read": "Fortsätt",
+	"glad_loud_crab_accept": "Acceptera inbjudan",
 	"flat_moving_finch_assure": "Skicka",
 	"shy_dizzy_jay_embrace": "Skicka koden igen",
 	"male_ornate_mantis_feel": "Välj ett starkt lösenord.",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -85,6 +85,7 @@
 	"less_free_osprey_buzz": "忘记密码？",
 	"major_noble_snake_drop": "使用 Google 登录",
 	"few_blue_wallaby_read": "继续",
+	"glad_loud_crab_accept": "接受邀请",
 	"flat_moving_finch_assure": "提交",
 	"shy_dizzy_jay_embrace": "重新发送验证码",
 	"male_ornate_mantis_feel": "选择一个强密码。",

--- a/src/routes/(app)/(minimal)/invite/[token]/+page.server.ts
+++ b/src/routes/(app)/(minimal)/invite/[token]/+page.server.ts
@@ -3,21 +3,17 @@ import { error } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 
 import { InviteStatus } from '$lib/data/enums.js';
+import { redirectLocalized } from '$lib/i18n';
 import * as auth from '$lib/server/auth';
 import { db } from '$lib/server/db/index.js';
 import { invite, membership, organization } from '$lib/server/db/schema.js';
 import { syncOrgSeatCount } from '$lib/server/organization.js';
 import { createOrUpdateUser } from '$lib/server/user.js';
 
-export const load = async (event) => {
-	const otpToken = event.params.token;
+import type { Actions, RequestEvent } from './$types';
 
-	if (!otpToken) {
-		throw error(500, `No token found.`);
-	}
-
-	const otpTokenHash = await sha256Hash(otpToken);
-
+async function getValidInvite(token: string) {
+	const otpTokenHash = await sha256Hash(token);
 	const [existingInvite] = await db.select().from(invite).where(eq(invite.token, otpTokenHash));
 
 	if (!existingInvite) {
@@ -32,48 +28,71 @@ export const load = async (event) => {
 		throw error(401, `Invitation expired. Request new one.`);
 	}
 
-	try {
-		// Create or update user
-		const { userId, passwordHash } = await createOrUpdateUser({
-			email: existingInvite.email,
-			name: existingInvite.name,
-			emailVerified: true
-		});
+	return existingInvite;
+}
 
-		// Add to membership
-		if (userId && existingInvite.organizationId) {
-			await db.insert(membership).values({
-				userId: userId,
-				organizationId: existingInvite.organizationId,
-				role: existingInvite.membershipRole
+export const load = async (event) => {
+	const otpToken = event.params.token;
+
+	if (!otpToken) {
+		throw error(500, `No token found.`);
+	}
+
+	const existingInvite = await getValidInvite(otpToken);
+
+	let organizationName = '';
+	if (existingInvite.organizationId) {
+		const [organizationResult] = await db
+			.select()
+			.from(organization)
+			.where(eq(organization.id, existingInvite.organizationId));
+
+		organizationName = organizationResult?.name ?? '';
+	}
+
+	return {
+		organizationName,
+		email: existingInvite.email
+	};
+};
+
+export const actions: Actions = {
+	acceptInvitation: async (event: RequestEvent) => {
+		const otpToken = event.params.token;
+
+		if (!otpToken) {
+			throw error(500, `No token found.`);
+		}
+
+		const existingInvite = await getValidInvite(otpToken);
+
+		let passwordHash: string | null | undefined;
+
+		try {
+			const result = await createOrUpdateUser({
+				email: existingInvite.email,
+				name: existingInvite.name,
+				emailVerified: true
 			});
-			// Sync Stripe subscription quantity (fire-and-forget)
-			syncOrgSeatCount(existingInvite.organizationId).catch(console.error);
+
+			if (result.userId && existingInvite.organizationId) {
+				await db.insert(membership).values({
+					userId: result.userId,
+					organizationId: existingInvite.organizationId,
+					role: existingInvite.membershipRole
+				});
+				syncOrgSeatCount(existingInvite.organizationId).catch(console.error);
+			}
+
+			await db.delete(invite).where(eq(invite.id, existingInvite.id));
+			await auth.createSession(event, result.userId);
+
+			passwordHash = result.passwordHash;
+		} catch (e) {
+			console.error(e);
+			error(500, 'Failed to accept invitation.');
 		}
 
-		// Cleanup
-		await db.delete(invite).where(eq(invite.id, existingInvite.id));
-
-		// Create session
-		await auth.createSession(event, userId);
-
-		// Get organization name from invite
-		let organizationName = '';
-		if (existingInvite.organizationId) {
-			const [organizationResult] = await db
-				.select()
-				.from(organization)
-				.where(eq(organization.id, existingInvite.organizationId));
-
-			organizationName = organizationResult.name;
-		}
-
-		return {
-			organizationName: organizationName,
-			hasPassword: !!passwordHash
-		};
-	} catch (e) {
-		console.error(e);
-		error(500, 'Failed to register.');
+		return redirectLocalized(303, passwordHash ? '/account' : '/set-password');
 	}
 };

--- a/src/routes/(app)/(minimal)/invite/[token]/+page.svelte
+++ b/src/routes/(app)/(minimal)/invite/[token]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
 	import { SingleFormPage } from '$lib/components/page';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import Link from '$lib/components/ui/link';
@@ -17,9 +18,9 @@
 		? m.tough_keen_bee_pause({ organizationName: data.organizationName })
 		: m.simple_last_slug_lend()}
 >
-	<Button class="mt-12 w-full" href={localizeHref(data.hasPassword ? '/account' : '/set-password')}
-		>{m.few_blue_wallaby_read()}</Button
-	>
+	<form method="POST" action="?/acceptInvitation" use:enhance class="mt-12">
+		<Button type="submit" class="w-full">{m.glad_loud_crab_accept()}</Button>
+	</form>
 	<div class="py-5">
 		<Separator />
 	</div>


### PR DESCRIPTION
## Summary

- Invitation links were being consumed by email prefetchers and security scanners before the actual user clicked them, causing "Invitation expired" errors on legitimate clicks
- Moved all side effects (create user, add membership, create session) from the `load` function into a new `acceptInvitation` form action
- The `load` function now only validates the token and returns invite metadata for display
- Added an "Accept Invitation" submit button to replace the old "Continue" link
- Added `glad_loud_crab_accept` i18n key translated into all 13 locales

## Test plan

- [ ] Visit an invite link — should show org name and "Accept Invitation" button without consuming the invite
- [ ] Click "Accept Invitation" — should create the user, add to org, and redirect to `/set-password` (new user) or `/account` (existing user)
- [ ] Visit the same invite link again after accepting — should show "Invitation has been accepted already"
- [ ] Simulate email prefetch by making a GET request to the invite URL — confirm invite is NOT consumed (can still be accepted)
- [ ] Verify expired invite shows correct error on both GET and POST

🤖 Generated with [Claude Code](https://claude.com/claude-code)