### PR TITLE
Add Google Ads gtag for new-user ads experiment

### DIFF
--- a/src/lib/client/gtag.ts
+++ b/src/lib/client/gtag.ts
@@ -1,0 +1,36 @@
+import { browser } from '$app/environment';
+
+// Google Ads tag (gtag.js) — used for the ads experiment.
+const GTAG_ID = 'AW-18238501590';
+
+declare global {
+	interface Window {
+		dataLayer: unknown[];
+	}
+}
+
+let initialized = false;
+
+// Injects the gtag.js script and bootstraps the global config.
+// Call once on mount; only invoke when the visitor is part of the experiment.
+export function initGtag() {
+	if (!browser || initialized) {
+		return;
+	}
+	initialized = true;
+
+	const script = document.createElement('script');
+	script.async = true;
+	script.src = `https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`;
+	document.head.appendChild(script);
+
+	window.dataLayer = window.dataLayer || [];
+	// gtag pushes its raw `arguments` object onto dataLayer (per Google's snippet);
+	// GTM relies on the arguments object specifically, not a plain array.
+	const gtag: (...args: unknown[]) => void = function () {
+		// eslint-disable-next-line prefer-rest-params
+		window.dataLayer.push(arguments);
+	};
+	gtag('js', new Date());
+	gtag('config', GTAG_ID);
+}

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -53,6 +53,7 @@ export async function validateSessionToken(token: string) {
 				picture: table.user.picture,
 				preferences: table.user.preferences,
 				encryptionEnabled: table.user.encryptionEnabled,
+				createdAt: table.user.createdAt,
 				hasPassword: sql<boolean>`${table.user.passwordHash} IS NOT NULL`.as('has_password')
 			},
 			session: table.session

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -4,6 +4,15 @@ import { hasNeedsRecoveryCookie } from '$lib/server/cookies';
 
 import type { LayoutServerLoad } from './$types';
 
+// Ads experiment: only load gtag for visitors who are not pre-existing users.
+// Anonymous visitors and users created on/after this date are included; users
+// created before it are excluded. Fixed launch date (not a rolling "today") so a
+// user's eligibility doesn't change over time.
+const ADS_EXPERIMENT_START = new Date('2026-06-14T00:00:00Z');
+
+const showAdsTracking = (user: App.Locals['user']) =>
+	!user || user.createdAt >= ADS_EXPERIMENT_START;
+
 // Routes excluded from the mandatory encryption guard
 const ENCRYPTION_GUARD_EXCLUDED = [
 	'/encryption',
@@ -30,7 +39,7 @@ export const load: LayoutServerLoad = async (event) => {
 	const user = event.locals.user;
 
 	if (!user) {
-		return { user, baseUrl: getBaseUrl() };
+		return { user, baseUrl: getBaseUrl(), showAdsTracking: showAdsTracking(user) };
 	}
 
 	// Strip locale prefix if present (e.g. /en, /de, /zh-CN)
@@ -64,6 +73,7 @@ export const load: LayoutServerLoad = async (event) => {
 	return {
 		user,
 		effectiveTier: event.locals.effectiveTier,
-		baseUrl: getBaseUrl()
+		baseUrl: getBaseUrl(),
+		showAdsTracking: showAdsTracking(user)
 	};
 };

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -3,6 +3,7 @@
 
 	import { page } from '$app/state';
 	import { PUBLIC_ENV } from '$env/static/public';
+	import { initGtag } from '$lib/client/gtag';
 	import { plausible } from '$lib/client/plausible';
 	import Progress from '$lib/components/blocks/progress.svelte';
 	import { appName } from '$lib/data/app';
@@ -10,13 +11,18 @@
 
 	import type { LayoutData } from './$types';
 
-	let { children }: { data: LayoutData; children: Snippet } = $props();
+	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 
 	onMount(async () => {
 		if (plausible) {
 			const { enableAutoPageviews } = plausible;
 
 			enableAutoPageviews();
+		}
+
+		// Ads experiment: excluded for users created before the experiment launch.
+		if (data.showAdsTracking) {
+			initGtag();
 		}
 
 		console.info(


### PR DESCRIPTION
Load gtag.js (AW-18238501590) only for anonymous visitors and users created on/after the experiment launch date; pre-existing users are excluded. The tag is loaded client-side from the (app) layout, gated by a server-computed flag, mirroring the existing Plausible setup.