### PR TITLE
refactor(stripe): create personal Stripe customer lazily at checkout

### DIFF
--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -12,7 +12,6 @@ import {
 	userSettings
 } from './db/schema';
 import { addContactToAudience } from './resend';
-import stripeInstance from './stripe';
 import { sendWelcomeEmail } from './transactional-email';
 
 // --- Encryption Key Management Actions ---
@@ -110,17 +109,9 @@ export const createOrUpdateUser = async ({
 		})
 		.returning();
 
-	// In case a user doesn't have a stripe account, we create one
-	if (!userResult.stripeCustomerId) {
-		const stripeCustomer = await stripeInstance.customers.create({
-			email: userResult.email
-		});
-
-		await db
-			.update(userSchema)
-			.set({ stripeCustomerId: stripeCustomer.id })
-			.where(eq(userSchema.id, userResult.id));
-	}
+	// Note: We no longer create a Stripe customer here. A personal Stripe customer
+	// is created lazily on first checkout (see src/routes/api/v1/plans/checkout/+server.ts),
+	// mirroring how organizations handle it.
 
 	// Add user settings
 	await db

--- a/src/routes/api/v1/plans/checkout/+server.ts
+++ b/src/routes/api/v1/plans/checkout/+server.ts
@@ -8,7 +8,7 @@ import { MembershipRole } from '$lib/data/enums';
 import { getAbsoluteLocalizedUrl } from '$lib/i18n';
 import { m } from '$lib/paraglide/messages.js';
 import { db } from '$lib/server/db';
-import { organization } from '$lib/server/db/schema';
+import { organization, user } from '$lib/server/db/schema';
 import { getMembersByOrganizationId, getOrganizationsByUserId } from '$lib/server/organization';
 import stripeInstance from '$lib/server/stripe';
 
@@ -77,8 +77,16 @@ export const POST = async ({ locals, request }: RequestEvent) => {
 	}
 
 	// Personal plan checkout
-	if (!locals.user.stripeCustomerId) {
-		throw new Error('No stripe id associated with user.');
+
+	// Get or create Stripe customer for the user
+	let stripeCustomerId = locals.user.stripeCustomerId;
+	if (!stripeCustomerId) {
+		const customer = await stripeInstance.customers.create({
+			email: locals.user.email,
+			metadata: { userId: locals.user.id }
+		});
+		stripeCustomerId = customer.id;
+		await db.update(user).set({ stripeCustomerId }).where(eq(user.id, locals.user.id));
 	}
 
 	try {
@@ -86,7 +94,7 @@ export const POST = async ({ locals, request }: RequestEvent) => {
 			locale: 'auto',
 			mode: 'subscription',
 			allow_promotion_codes: true,
-			customer: locals.user.stripeCustomerId,
+			customer: stripeCustomerId,
 			currency,
 			line_items: [{ price: priceId, quantity: 1 }],
 			subscription_data: {


### PR DESCRIPTION
## What

Stop creating a Stripe customer for every user at signup. Instead, create the personal Stripe customer lazily on first checkout (get-or-create), mirroring how organizations already work.

## Why

Most users never subscribe, so eagerly creating a Stripe customer on every signup produces unused customers and an extra Stripe API call on the signup hot path.

## Changes

- `src/lib/server/user.ts` — Removed the eager `stripe.customers.create` block from `createOrUpdateUser` (and the now-unused `stripeInstance` import).
- `src/routes/api/v1/plans/checkout/+server.ts` — Personal checkout `POST` now does get-or-create: creates the customer (with `metadata: { userId }`) and persists `stripeCustomerId` before creating the checkout session.

## Safety checks

- **Existing users** keep their `stripeCustomerId` — lazy path only fires when it's null, no migration needed.
- **Webhook reverse-lookup** (`user.stripeCustomerId == subscription.customer`) still works: the id is persisted before the checkout session is created.
- All other readers (profile, pricing load, delete-account, "manage subscription") already guard with `if (stripeCustomerId)`.
- Checkout `PUT` (subscription change) still throws when no customer — correct, since updating a subscription presupposes one exists.
- No personal email-change flow exists (`saveUser` only updates `name`), so no stale-email gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)