### PR TITLE
Change main headline back to "Share a Secret"

### DIFF
--- a/messages/da.json
+++ b/messages/da.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 time",
 	"raw_stout_felix_empower": "{amount} timer",
 	"curly_few_parrot_savor": "{amount} dage",
-	"lucky_warm_mayfly_engage": "Del i fortrolighed.",
+	"lucky_warm_mayfly_engage": "Del en hemmelighed",
 	"aloof_quaint_snail_pave": "Send adgangskoder, private filer og alle de hemmeligheder, der ikke bør ligge i din indbakke. <span class=\"gradient-text\">End-to-end-krypteret.</span> Flygtig. Open source.",
 	"sea_giant_flamingo_forgive": "End-to-end-krypteret",
 	"mean_smug_loris_cherish": "Uden spor",

--- a/messages/de.json
+++ b/messages/de.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 Stunde",
 	"raw_stout_felix_empower": "{amount} Stunden",
 	"curly_few_parrot_savor": "{amount} Tage",
-	"lucky_warm_mayfly_engage": "Vertraulich teilen.",
+	"lucky_warm_mayfly_engage": "Teile ein Geheimnis",
 	"aloof_quaint_snail_pave": "Sende Passwörter, private Dateien und alle Geheimnisse, die nicht in deinem Posteingang bleiben sollten. <span class=\"gradient-text\">Ende-zu-Ende verschlüsselt.</span> Kurzlebig. Open-Source.",
 	"sea_giant_flamingo_forgive": "Ende-zu-Ende-verschlüsselt",
 	"mean_smug_loris_cherish": "Ohne Spuren",

--- a/messages/en.json
+++ b/messages/en.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 hour",
 	"raw_stout_felix_empower": "{amount} hours",
 	"curly_few_parrot_savor": "{amount} days",
-	"lucky_warm_mayfly_engage": "Share in confidence.",
+	"lucky_warm_mayfly_engage": "Share a Secret",
 	"aloof_quaint_snail_pave": "Send passwords, private files, and all the secrets that shouldn't live in your inbox. <span class=\"gradient-text\">End-to-end encrypted.</span> Ephemeral. Open-source.",
 	"sea_giant_flamingo_forgive": "End-to-end-encrypted",
 	"mean_smug_loris_cherish": "Without a trace",

--- a/messages/es.json
+++ b/messages/es.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 hora",
 	"raw_stout_felix_empower": "{amount} horas",
 	"curly_few_parrot_savor": "{amount} días",
-	"lucky_warm_mayfly_engage": "Comparte con confianza.",
+	"lucky_warm_mayfly_engage": "Comparte un secreto",
 	"aloof_quaint_snail_pave": "Envía contraseñas, archivos privados y todos los secretos que no deberían vivir en tu bandeja de entrada. <span class=\"gradient-text\">Cifrado de extremo a extremo.</span> Efímero. Código abierto.",
 	"sea_giant_flamingo_forgive": "Cifrado de extremo a extremo",
 	"mean_smug_loris_cherish": "Sin dejar rastro",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 heure",
 	"raw_stout_felix_empower": "{amount} heures",
 	"curly_few_parrot_savor": "{amount} jours",
-	"lucky_warm_mayfly_engage": "Partagez en toute confiance.",
+	"lucky_warm_mayfly_engage": "Partagez un secret",
 	"aloof_quaint_snail_pave": "Envoyez vos mots de passe, fichiers privés et tous les secrets qui ne devraient pas traîner dans votre boîte mail. <span class=\"gradient-text\">Chiffrement de bout en bout.</span> Éphémère. Open-source.",
 	"sea_giant_flamingo_forgive": "Chiffré de bout en bout",
 	"mean_smug_loris_cherish": "Sans laisser de traces",

--- a/messages/it.json
+++ b/messages/it.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 ora",
 	"raw_stout_felix_empower": "{amount} ore",
 	"curly_few_parrot_savor": "{amount} giorni",
-	"lucky_warm_mayfly_engage": "Condividi in tutta fiducia.",
+	"lucky_warm_mayfly_engage": "Condividi un segreto",
 	"aloof_quaint_snail_pave": "Invia password, file privati e tutti i segreti che non dovrebbero stare nella tua casella di posta. <span class=\"gradient-text\">Crittografati end-to-end.</span> Effimeri. Open-source.",
 	"sea_giant_flamingo_forgive": "Crittografato end-to-end",
 	"mean_smug_loris_cherish": "Senza lasciare traccia",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 時間",
 	"raw_stout_felix_empower": "{amount} 時間",
 	"curly_few_parrot_savor": "{amount} 日",
-	"lucky_warm_mayfly_engage": "安心して共有を。",
+	"lucky_warm_mayfly_engage": "秘密を共有",
 	"aloof_quaint_snail_pave": "パスワード、プライベートファイル、受信トレイに残すべきでないすべてのシークレットを送信。<span class=\"gradient-text\">エンドツーエンド暗号化。</span>一時的。オープンソース。",
 	"sea_giant_flamingo_forgive": "エンドツーエンド暗号化",
 	"mean_smug_loris_cherish": "痕跡なし",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 uur",
 	"raw_stout_felix_empower": "{amount} uur",
 	"curly_few_parrot_savor": "{amount} dagen",
-	"lucky_warm_mayfly_engage": "Deel in vertrouwen.",
+	"lucky_warm_mayfly_engage": "Deel een geheim",
 	"aloof_quaint_snail_pave": "Verstuur wachtwoorden, privébestanden en alle geheimen die niet in je inbox thuishoren. <span class=\"gradient-text\">End-to-end versleuteld.</span> Tijdelijk. Open source.",
 	"sea_giant_flamingo_forgive": "End-to-end versleuteld",
 	"mean_smug_loris_cherish": "Zonder een spoor",

--- a/messages/no.json
+++ b/messages/no.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 time",
 	"raw_stout_felix_empower": "{amount} timer",
 	"curly_few_parrot_savor": "{amount} dager",
-	"lucky_warm_mayfly_engage": "Del i fortrolighet.",
+	"lucky_warm_mayfly_engage": "Del en hemmelighet",
 	"aloof_quaint_snail_pave": "Send passord, private filer og alle hemmelighetene som ikke bør ligge i innboksen din. <span class=\"gradient-text\">Ende-til-ende-kryptert.</span> Flyktig. Åpen kildekode.",
 	"sea_giant_flamingo_forgive": "Ende-til-ende-kryptert",
 	"mean_smug_loris_cherish": "Uten spor",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 godzina",
 	"raw_stout_felix_empower": "{amount} godzin",
 	"curly_few_parrot_savor": "{amount} dni",
-	"lucky_warm_mayfly_engage": "Udostępniaj w zaufaniu.",
+	"lucky_warm_mayfly_engage": "Udostępnij sekret",
 	"aloof_quaint_snail_pave": "Wysyłaj hasła, prywatne pliki i wszystkie sekrety, które nie powinny trafiać do Twojej skrzynki odbiorczej. <span class=\"gradient-text\">Szyfrowane end-to-end.</span> Ulotne. Open-source.",
 	"sea_giant_flamingo_forgive": "Szyfrowane end-to-end",
 	"mean_smug_loris_cherish": "Bez śladu",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 hora",
 	"raw_stout_felix_empower": "{amount} horas",
 	"curly_few_parrot_savor": "{amount} dias",
-	"lucky_warm_mayfly_engage": "Partilhe com confiança.",
+	"lucky_warm_mayfly_engage": "Partilhe um segredo",
 	"aloof_quaint_snail_pave": "Envie senhas, ficheiros privados e todos os segredos que não deveriam ficar na sua caixa de entrada. <span class=\"gradient-text\">Encriptação ponta a ponta.</span> Efémero. Open-source.",
 	"sea_giant_flamingo_forgive": "Criptografado ponta a ponta",
 	"mean_smug_loris_cherish": "Sem deixar rasto",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 час",
 	"raw_stout_felix_empower": "{amount} часов",
 	"curly_few_parrot_savor": "{amount} дней",
-	"lucky_warm_mayfly_engage": "Делитесь конфиденциально.",
+	"lucky_warm_mayfly_engage": "Поделитесь секретом",
 	"aloof_quaint_snail_pave": "Отправляйте пароли, личные файлы и всё, чему не место в вашем почтовом ящике. <span class=\"gradient-text\">Сквозное шифрование.</span> Эфемерно. Open-source.",
 	"sea_giant_flamingo_forgive": "Сквозное шифрование",
 	"mean_smug_loris_cherish": "Без следов",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 timme",
 	"raw_stout_felix_empower": "{amount} timmar",
 	"curly_few_parrot_savor": "{amount} dagar",
-	"lucky_warm_mayfly_engage": "Dela i förtroende.",
+	"lucky_warm_mayfly_engage": "Dela en hemlighet",
 	"aloof_quaint_snail_pave": "Skicka lösenord, privata filer och alla hemligheter som inte borde ligga i din inkorg. <span class=\"gradient-text\">Totalsträckskrypterat.</span> Flyktigt. Öppen källkod.",
 	"sea_giant_flamingo_forgive": "Totalsträckskrypterad",
 	"mean_smug_loris_cherish": "Utan ett spår",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -176,7 +176,7 @@
 	"close_pink_ant_radiate": "1 小时",
 	"raw_stout_felix_empower": "{amount} 小时",
 	"curly_few_parrot_savor": "{amount} 天",
-	"lucky_warm_mayfly_engage": "放心分享。",
+	"lucky_warm_mayfly_engage": "分享秘密",
 	"aloof_quaint_snail_pave": "发送密码、私密文件以及所有不该留在收件箱里的秘密。<span class=\"gradient-text\">端到端加密。</span>短暂留存。开源。",
 	"sea_giant_flamingo_forgive": "端到端加密",
 	"mean_smug_loris_cherish": "不留痕迹",


### PR DESCRIPTION
## Summary
- Reverts the homepage headline from "Share in confidence." back to "Share a Secret"
- Re-translates the `lucky_warm_mayfly_engage` key across all 13 non-English locales (de, es, fr, pt, ru, zh-CN, it, pl, sv, nl, ja, no, da)

The key is used as the homepage `<Page title>` in `src/routes/(app)/(default)/+page.svelte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)