### PR TITLE
feat(social): add Bluesky and LinkedIn links

### DIFF
--- a/messages/da.json
+++ b/messages/da.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Følg os",
 	"keen_proud_otter_news": "Secret Requests er ude af beta",
 	"bold_neat_otter_gate": "Secret Requests er tilgængelig fra Top Secret-abonnementet og opefter.",
 	"fresh_calm_heron_note": "Nyt:",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Folge uns",
 	"keen_proud_otter_news": "Secret Requests verlässt die Beta",
 	"bold_neat_otter_gate": "Secret Requests ist im Top Secret-Tarif und höher verfügbar.",
 	"fresh_calm_heron_note": "Neu:",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Follow us",
 	"keen_proud_otter_news": "Secret Requests is out of beta",
 	"bold_neat_otter_gate": "Secret Requests is available on the Top Secret plan and above.",
 	"fresh_calm_heron_note": "New:",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Síguenos",
 	"keen_proud_otter_news": "Secret Requests sale de la beta",
 	"bold_neat_otter_gate": "Secret Requests está disponible en el plan Top Secret y superiores.",
 	"fresh_calm_heron_note": "Nuevo:",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Suivez-nous",
 	"keen_proud_otter_news": "Secret Requests sort de la bêta",
 	"bold_neat_otter_gate": "Secret Requests est disponible à partir du forfait Top Secret.",
 	"fresh_calm_heron_note": "Nouveau :",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Seguici",
 	"keen_proud_otter_news": "Secret Requests esce dalla beta",
 	"bold_neat_otter_gate": "Secret Requests è disponibile nel piano Top Secret e superiori.",
 	"fresh_calm_heron_note": "Novità:",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "フォローする",
 	"keen_proud_otter_news": "Secret Requests がベータ版を卒業しました",
 	"bold_neat_otter_gate": "Secret Requests は Top Secret プラン以上でご利用いただけます。",
 	"fresh_calm_heron_note": "新着：",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Volg ons",
 	"keen_proud_otter_news": "Secret Requests is uit bèta",
 	"bold_neat_otter_gate": "Secret Requests is beschikbaar vanaf het Top Secret-abonnement.",
 	"fresh_calm_heron_note": "Nieuw:",

--- a/messages/no.json
+++ b/messages/no.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Følg oss",
 	"keen_proud_otter_news": "Secret Requests er ute av beta",
 	"bold_neat_otter_gate": "Secret Requests er tilgjengelig fra Top Secret-planen og oppover.",
 	"fresh_calm_heron_note": "Nytt:",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Obserwuj nas",
 	"keen_proud_otter_news": "Secret Requests wychodzi z fazy beta",
 	"bold_neat_otter_gate": "Secret Requests jest dostępne w planie Top Secret i wyższych.",
 	"fresh_calm_heron_note": "Nowość:",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Siga-nos",
 	"keen_proud_otter_news": "Secret Requests saiu da versão beta",
 	"bold_neat_otter_gate": "Secret Requests está disponível no plano Top Secret e superiores.",
 	"fresh_calm_heron_note": "Novo:",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Подписывайтесь на нас",
 	"keen_proud_otter_news": "Secret Requests вышел из беты",
 	"bold_neat_otter_gate": "Secret Requests доступен в тарифе Top Secret и выше.",
 	"fresh_calm_heron_note": "Новое:",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "Följ oss",
 	"keen_proud_otter_news": "Secret Requests lämnar betan",
 	"bold_neat_otter_gate": "Secret Requests är tillgängligt från Top Secret-planen och uppåt.",
 	"fresh_calm_heron_note": "Nytt:",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
+	"social_follow_heading": "关注我们",
 	"keen_proud_otter_news": "Secret Requests 已结束测试版",
 	"bold_neat_otter_gate": "Secret Requests 在 Top Secret 套餐及以上版本中提供。",
 	"fresh_calm_heron_note": "新增：",

--- a/src/lib/components/blocks/footer.svelte
+++ b/src/lib/components/blocks/footer.svelte
@@ -17,6 +17,7 @@
 	import LanguageSwitcher from '../ui/language-switcher';
 	import FooterMenu from '../ui/menu';
 	import DarkModeSwitcher from './dark-mode-switcher.svelte';
+	import SocialLinks from './social-links.svelte';
 </script>
 
 <footer class="border-border bg-background border-t pt-14 shadow-[0_0_60px_0_rgba(0,0,0,0.08)]">
@@ -65,6 +66,7 @@
 			</div>
 
 			<div class="ms-auto flex items-center gap-4 py-5 md:py-2">
+				<SocialLinks />
 				<DarkModeSwitcher />
 				<LanguageSwitcher />
 			</div>

--- a/src/lib/components/blocks/social-links.svelte
+++ b/src/lib/components/blocks/social-links.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { cn } from '$lib/client/utils';
+	import { blueskyUrl, linkedinUrl } from '$lib/data/app';
+
+	let { class: className }: { class?: string } = $props();
+
+	const socialLinks = [
+		{
+			label: 'Bluesky',
+			href: blueskyUrl,
+			path: 'M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078a8.741 8.741 0 0 1-.415-.056c.14.017.279.036.415.056 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.479 0-.688-.139-1.86-.902-2.203-.659-.299-1.664-.621-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8Z'
+		},
+		{
+			label: 'LinkedIn',
+			href: linkedinUrl,
+			path: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z'
+		}
+	];
+</script>
+
+<div class={cn('flex items-center gap-1', className)}>
+	{#each socialLinks as { label, href, path } (label)}
+		<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+		<a
+			class="text-muted-foreground hover:text-foreground inline-flex p-2 transition-colors"
+			{href}
+			target="_blank"
+			rel="noopener noreferrer"
+			aria-label={label}
+		>
+			<svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+				<path d={path} />
+			</svg>
+		</a>
+	{/each}
+</div>

--- a/src/lib/data/app.ts
+++ b/src/lib/data/app.ts
@@ -25,6 +25,8 @@ export const emailSupport = 'support@scrt.link';
 export const emailNoReply = 'no-reply@scrt.link';
 export const uptimerobotUrl = 'https://stats.uptimerobot.com/v5yqDuEr5z';
 export const githubUrl = 'https://github.com/stophecom/scrt-link-v2';
+export const blueskyUrl = 'https://bsky.app/profile/scrt.link';
+export const linkedinUrl = 'https://www.linkedin.com/company/santihans';
 
 export const privacyFeatures = () => [
 	{

--- a/src/routes/(app)/(default)/about/+page.svelte
+++ b/src/routes/(app)/(default)/about/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import SocialLinks from '$lib/components/blocks/social-links.svelte';
 	import Page from '$lib/components/page/default-page.svelte';
 	import Container from '$lib/components/ui/container/container.svelte';
 	import Markdown from '$lib/components/ui/markdown';
@@ -13,5 +14,9 @@
 >
 	<Container>
 		<Markdown markdown={m.polite_clean_canary_walk()} format={true} />
+		<div class="mt-6">
+			<h5 class="text-primary mb-1 font-semibold">{m.social_follow_heading()}</h5>
+			<SocialLinks class="-ms-2" />
+		</div>
 	</Container>
 </Page>

--- a/src/routes/(app)/(default)/contact/+page.svelte
+++ b/src/routes/(app)/(default)/contact/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import SocialLinks from '$lib/components/blocks/social-links.svelte';
 	import ContactForm from '$lib/components/forms/contact-form.svelte';
 	import Page from '$lib/components/page/default-page.svelte';
 	import Card from '$lib/components/ui/card';
@@ -18,6 +19,10 @@
 		</Card>
 		<div class="prose">
 			<a href="mailto:{emailSupport}">{emailSupport}</a>
+		</div>
+		<div class="mt-6">
+			<h5 class="text-primary mb-1 font-semibold">{m.social_follow_heading()}</h5>
+			<SocialLinks class="-ms-2" />
 		</div>
 	</Container>
 </Page>


### PR DESCRIPTION
## Summary

Adds **Bluesky** and **LinkedIn** social media links across the site via a new reusable block.

- **New component** `src/lib/components/blocks/social-links.svelte` — renders the Bluesky and LinkedIn brand logos as inline SVGs (icon-only links with `aria-label`, `target="_blank"`, `rel="noopener noreferrer"`). URLs come from `src/lib/data/app.ts` (single source of truth).
- **Footer** — icons placed next to the dark-mode / language switchers.
- **/about** & **/contact** — icons under a translated "Follow us" heading.
- Added `blueskyUrl` / `linkedinUrl` to `app.ts`.
- Added the `social_follow_heading` i18n key to `en.json` and translated it into all 13 other locales.

## Notes

- **LinkedIn URL** normalized to `https://www.linkedin.com/company/santihans` — dropped the `?viewAsMember=true` flag (admin preview param, not for public use).
- **Bluesky URL**: `https://bsky.app/profile/scrt.link`.

## Verification

- `pnpm lint` clean; `pnpm check` shows no errors in changed files.
- Verified in the running dev server: footer, /about, and /contact all render both icons with correct hrefs (see screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)