### PR TITLE
fix(secret-requests): make URL hash fragment fully URL-safe

### DIFF
--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -30,7 +30,9 @@ export const generateUuid = () => crypto.randomUUID();
 export const generateRandomUrlSafeString = (length = 36) => {
 	const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 	const numbers = '0123456789';
-	const specialCharacters = '$~-_.'; // Technically more characters are allowed in the fragment identifier part of the URL.
+	// Restricted to the base64url alphabet (RFC 3986 unreserved): never percent-encoded,
+	// never mangled by email/chat clients, and leaves `.` free as a fragment delimiter.
+	const specialCharacters = '-_';
 	const charset = [...letters, ...numbers, ...specialCharacters];
 
 	const values = getRandomBytes(length);
@@ -61,6 +63,16 @@ export const base64ToBinary = (base64: string) => {
 
 	return stringToArrayBuffer(base64Decoded);
 };
+
+// Base64url (RFC 4648 §5): uses `-` `_` instead of `+` `/` and drops `=` padding.
+// Safe to place in a URL fragment without percent-encoding or client mangling.
+export const binaryToBase64Url = (arrayBuffer: ArrayBuffer) =>
+	binaryToBase64(arrayBuffer).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+// Tolerant decoder: accepts both base64url (new links) and standard base64 (legacy
+// links). `atob` handles missing `=` padding, so we only need to map the alphabet back.
+export const base64UrlToBinary = (base64Url: string) =>
+	base64ToBinary(base64Url.replace(/-/g, '+').replace(/_/g, '/'));
 
 export const encryptData = async (
 	data: ArrayBuffer,

--- a/packages/core/src/rsa.ts
+++ b/packages/core/src/rsa.ts
@@ -2,7 +2,14 @@
 // Used when a requester wants to receive encrypted data from someone without a shared secret.
 // The requester generates an RSA key pair; the responder encrypts with the public key.
 
-import { base64ToBinary, binaryToBase64, decodeText, encodeText } from './crypto';
+import {
+	base64ToBinary,
+	base64UrlToBinary,
+	binaryToBase64,
+	binaryToBase64Url,
+	decodeText,
+	encodeText
+} from './crypto';
 
 const RSA_ALGORITHM = 'RSA-OAEP';
 const RSA_HASH = 'SHA-256';
@@ -189,7 +196,8 @@ export async function encryptRequestNote(note: string): Promise<{
 }> {
 	const aesKey = await generateAESKey();
 	const rawKey = await crypto.subtle.exportKey('raw', aesKey);
-	const noteKey = binaryToBase64(rawKey);
+	// base64url so the key is safe to drop into a URL fragment unencoded.
+	const noteKey = binaryToBase64Url(rawKey);
 	const encryptedNote = await encryptResponseContent(note, aesKey);
 	return { encryptedNote, noteKey };
 }
@@ -201,7 +209,8 @@ export async function decryptRequestNote(
 	encryptedNote: string,
 	noteKeyBase64: string
 ): Promise<string> {
-	const rawKey = base64ToBinary(noteKeyBase64);
+	// base64UrlToBinary also decodes legacy standard-base64 keys from older links.
+	const rawKey = base64UrlToBinary(noteKeyBase64);
 	const aesKey = await crypto.subtle.importKey(
 		'raw',
 		rawKey,

--- a/src/lib/components/blocks/secret-response.svelte
+++ b/src/lib/components/blocks/secret-response.svelte
@@ -37,9 +37,11 @@
 		if (data.encryptedNote) {
 			const hash = page.url.hash.slice(1);
 			if (hash) {
-				const pipeIndex = hash.indexOf('|');
-				if (pipeIndex !== -1) {
-					const noteKey = hash.substring(pipeIndex + 1);
+				// New links use `.` as delimiter; legacy links use `|`. Check `|` first so a
+				// legacy requestId (whose old charset could contain `.`) is split correctly.
+				const delimiterIndex = hash.includes('|') ? hash.indexOf('|') : hash.indexOf('.');
+				if (delimiterIndex !== -1) {
+					const noteKey = hash.substring(delimiterIndex + 1);
 					try {
 						decryptedNote = await decryptRequestNote(data.encryptedNote, noteKey);
 					} catch {

--- a/src/lib/components/forms/secret-request-form.svelte
+++ b/src/lib/components/forms/secret-request-form.svelte
@@ -76,8 +76,9 @@
 			$formData.encryptedNote = encryptedNote;
 			$formData.encryptedNoteForOwner = encryptedNoteForOwner;
 
-			// Build the request link
-			const hashFragment = noteKey ? `${requestId}|${noteKey}` : requestId;
+			// Build the request link. `.` delimits requestId from noteKey; both are now
+			// base64url so the whole fragment stays URL-safe (no `|`, `+`, `/`, `=`).
+			const hashFragment = noteKey ? `${requestId}.${noteKey}` : requestId;
 			requestLink = `${page.url.origin}/r/${$formData.requestIdHash}#${hashFragment}`;
 
 			if (plausible) {


### PR DESCRIPTION
## Problem

Secret-request links look like:

```
https://scrt.link/r/<requestIdHash>#hT2zGd1~Z~zJCMpJ~RjN-gkXq4SsEFY.jlIA|GPE10xiN9pxWNyvYi+AXXiwI/tveY2sNnzkCoJUhHzc=
```

The hash fragment contained characters that are illegal or fragile in a URL:

- **`|`** — *not* a legal fragment character (RFC 3986). Slack, WhatsApp, and many email clients percent-encode it to `%7C` or truncate the auto-link at it. This was the separator between `requestId` and `noteKey`.
- **`+` `/` `=`** — from standard base64 in the note key. Legal-ish in a fragment, but base64-in-URL is a known footgun (`+`→space the moment anything re-parses it as a query).

## Fix

New links are now built entirely from RFC 3986 *unreserved* characters (`A-Za-z0-9-_.`) — never percent-encoded, never mangled, always fully auto-linkified.

- Add `binaryToBase64Url` / `base64UrlToBinary` in `@scrt-link/core`; the note key is now base64url (no `+` `/` `=`).
- Restrict `generateRandomUrlSafeString` to the base64url alphabet, freeing `.` as an unambiguous delimiter (entropy: 6.0 vs 6.07 bits/char — negligible).
- Use `.` instead of `|` as the fragment delimiter.

## Backward compatibility

Outstanding links issued before this change still resolve:

- The reader checks for `|` **first** (legacy), then `.` (new) — so a legacy `requestId` that may contain `.` is split correctly.
- `base64UrlToBinary` is tolerant and decodes legacy standard-base64 keys too.

## Verification

- 5,000-iteration round-trip check: base64url output is free of `+` `/` `=`, decodes back to the exact key, **and** legacy standard-base64 keys still decode. ✅
- `pnpm check`: no errors in any touched file. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)