### PR TITLE
fix(csp): allow Google domains for reCAPTCHA

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -31,7 +31,9 @@ const config = {
 					'self',
 					'https://js.stripe.com',
 					'https://vercel.live',
-					'https://www.googletagmanager.com'
+					'https://www.googletagmanager.com',
+					'https://www.google.com',
+					'https://www.gstatic.com'
 				],
 				'style-src': ['self', 'unsafe-inline'],
 				'img-src': [
@@ -57,7 +59,12 @@ const config = {
 					'https://googleads.g.doubleclick.net',
 					'https://www.googleadservices.com'
 				],
-				'frame-src': ['self', 'https://js.stripe.com', 'https://vercel.live'],
+				'frame-src': [
+					'self',
+					'https://js.stripe.com',
+					'https://vercel.live',
+					'https://www.google.com'
+				],
 				'worker-src': ['self'],
 				'object-src': ['none'],
 				'base-uri': ['self'],


### PR DESCRIPTION
## What

Extends the Content-Security-Policy in `svelte.config.js`:

- `script-src`: add `https://www.google.com` and `https://www.gstatic.com`
- `frame-src`: add `https://www.google.com`

## Why

Google reCAPTCHA loads its script from `www.google.com`/`www.gstatic.com` and renders its challenge in an iframe from `www.google.com`. Without these directives the browser blocks them with CSP violations.

> Note: this change was already present in the working tree and is split out here into its own PR, separate from the unrelated URL-safe-fragment fix (#284).

🤖 Generated with [Claude Code](https://claude.com/claude-code)