### PR TITLE
feat(analytics): track Signup event for new users

### DIFF
--- a/src/lib/client/plausible.ts
+++ b/src/lib/client/plausible.ts
@@ -9,3 +9,27 @@ export const plausible = browser
 			apiHost: dev ? 'https://plausible.io' : location.origin // We rewrite the host to tackle ad blockers. See vercel.json.
 		})
 	: undefined;
+
+const SIGNUP_TRACKING_COOKIE = 'signup-tracking';
+
+/**
+ * Fire a one-off Plausible "Signup" event when the server flagged a brand-new
+ * user via the `signup-tracking` cookie (value = signup method). Reads and clears
+ * the cookie so the event fires exactly once. Call on mount of the post-signup
+ * landing page (set-password), not globally.
+ */
+export const consumeSignupTracking = () => {
+	if (!plausible) return;
+
+	const method = document.cookie
+		.split('; ')
+		.find((c) => c.startsWith(`${SIGNUP_TRACKING_COOKIE}=`))
+		?.split('=')[1];
+
+	if (!method) return;
+
+	document.cookie = `${SIGNUP_TRACKING_COOKIE}=; path=/; max-age=0`;
+	plausible.trackEvent('Signup', {
+		props: { method, whiteLabelDomain: window.location.host }
+	});
+};

--- a/src/lib/server/cookies.ts
+++ b/src/lib/server/cookies.ts
@@ -8,6 +8,8 @@ export const EMAIL_VERIFICATION_COOKIE = 'email_verification';
 export const PASSWORD_VERIFIED_COOKIE = 'password-verified';
 export const RECOVERY_VERIFIED_COOKIE = 'recovery-verified';
 export const NEEDS_RECOVERY_COOKIE = 'needs-recovery';
+// Client-readable; kept in sync with the literal in $lib/client/plausible.ts.
+export const SIGNUP_TRACKING_COOKIE = 'signup-tracking';
 const GOOGLE_OAUTH_STATE_COOKIE = 'google_oauth_state';
 const GOOGLE_CODE_VERIFIER_COOKIE = 'google_code_verifier';
 
@@ -96,4 +98,22 @@ export function getGoogleOAuthCookies(event: RequestEvent) {
 		state: event.cookies.get(GOOGLE_OAUTH_STATE_COOKIE) ?? null,
 		codeVerifier: event.cookies.get(GOOGLE_CODE_VERIFIER_COOKIE) ?? null
 	};
+}
+
+// --- Signup tracking cookie ---
+
+/**
+ * Mark that a brand-new user was just created, so the client can fire a one-off
+ * Plausible "Signup" event after the post-signup redirect. Not httpOnly (read in
+ * the browser); `lax` so it survives the top-level OAuth redirect. The value is
+ * the signup method.
+ */
+export function setSignupTrackingCookie(event: RequestEvent, method: 'email' | 'google') {
+	event.cookies.set(SIGNUP_TRACKING_COOKIE, method, {
+		path: '/',
+		httpOnly: false,
+		secure: !dev,
+		sameSite: 'lax',
+		maxAge: 60 * 5 // 5 minutes
+	});
 }

--- a/src/lib/server/form/actions.ts
+++ b/src/lib/server/form/actions.ts
@@ -63,6 +63,7 @@ import {
 	RECOVERY_VERIFIED_COOKIE,
 	setEmailVerificationCookie,
 	setNeedsRecoveryCookie,
+	setSignupTrackingCookie,
 	setVerificationCookie
 } from '../cookies';
 import {
@@ -1060,13 +1061,16 @@ export const verifyEmailVerificationCode: Action = async (event) => {
 		// All check passed. We create or update user and session.
 
 		// Create or update user
-		const { userId, name } = await createOrUpdateUser({
+		const { userId, name, isNewUser } = await createOrUpdateUser({
 			email: email,
 			emailVerified: true
 		});
 
+		// Signal the client to fire a one-off Plausible "Signup" event after redirect.
+		if (isNewUser) setSignupTrackingCookie(event, 'email');
+
 		// This is only triggered, if new user
-		await welcomeNewUser({ email, name });
+		await welcomeNewUser({ email, name, isNewUser });
 
 		// Create session
 		await auth.createSession(event, userId);

--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -85,6 +85,9 @@ export const createOrUpdateUser = async ({
 	name,
 	picture
 }: PartialExcept<User, 'email'>) => {
+	// Determine newness before the upsert — afterwards the row always exists.
+	const isNewUser = !(await checkIfUserExists(email));
+
 	// Only include explicitly provided fields in the update set,
 	// so we don't overwrite existing values (e.g. name) with null.
 	const updateSet: Partial<Pick<User, 'emailVerified' | 'googleId' | 'name' | 'picture'>> = {
@@ -127,30 +130,34 @@ export const createOrUpdateUser = async ({
 			}
 		});
 
-	return { userId: userResult.id, ...userResult };
+	return { userId: userResult.id, isNewUser, ...userResult };
 };
 
-export const welcomeNewUser = async ({ email, name }: Pick<User, 'email' | 'name'>) => {
-	const isNewUser = !(await checkIfUserExists(email));
+// `isNewUser` must come from createOrUpdateUser (computed before the upsert).
+// We can't re-derive it here: the user row already exists by the time this runs.
+export const welcomeNewUser = async ({
+	email,
+	name,
+	isNewUser
+}: Pick<User, 'email' | 'name'> & { isNewUser: boolean }) => {
+	if (!isNewUser) return;
 
-	if (isNewUser) {
-		// We add user to MQL list on Resend
-		try {
-			const result = await addContactToAudience({ email });
+	// We add user to MQL list on Resend
+	try {
+		const result = await addContactToAudience({ email });
 
-			if (result.error) {
-				throw Error(result.error.message);
-			}
-		} catch (error) {
-			console.error(`Failed to add contact to Resend.`, JSON.stringify(error));
+		if (result.error) {
+			throw Error(result.error.message);
 		}
+	} catch (error) {
+		console.error(`Failed to add contact to Resend.`, JSON.stringify(error));
+	}
 
-		// Send welcome email
-		try {
-			await sendWelcomeEmail(email, name || '');
-		} catch (error) {
-			console.error(`Failed to send welcome email.`, JSON.stringify(error));
-		}
+	// Send welcome email
+	try {
+		await sendWelcomeEmail(email, name || '');
+	} catch (error) {
+		console.error(`Failed to send welcome email.`, JSON.stringify(error));
 	}
 };
 

--- a/src/routes/(app)/(minimal)/login/google/callback/+server.ts
+++ b/src/routes/(app)/(minimal)/login/google/callback/+server.ts
@@ -3,7 +3,7 @@ import { ArcticFetchError, OAuth2RequestError, type OAuth2Tokens } from 'arctic'
 
 import * as auth from '$lib/server/auth';
 import { google } from '$lib/server/auth';
-import { getGoogleOAuthCookies } from '$lib/server/cookies';
+import { getGoogleOAuthCookies, setSignupTrackingCookie } from '$lib/server/cookies';
 import { createOrUpdateUser, welcomeNewUser } from '$lib/server/user';
 
 export async function GET(event: RequestEvent): Promise<Response> {
@@ -31,7 +31,7 @@ export async function GET(event: RequestEvent): Promise<Response> {
 		const googleUser: UserInfoResponse = await response.json();
 
 		// Create or update user
-		const { userId, name, encryptionEnabled, passwordHash } = await createOrUpdateUser({
+		const { userId, name, encryptionEnabled, passwordHash, isNewUser } = await createOrUpdateUser({
 			email: googleUser.email,
 			emailVerified: googleUser.email_verified || false,
 			googleId: googleUser.sub,
@@ -39,7 +39,10 @@ export async function GET(event: RequestEvent): Promise<Response> {
 			name: googleUser.name
 		});
 
-		await welcomeNewUser({ email: googleUser.email, name });
+		// Signal the client to fire a one-off Plausible "Signup" event after redirect.
+		if (isNewUser) setSignupTrackingCookie(event, 'google');
+
+		await welcomeNewUser({ email: googleUser.email, name, isNewUser });
 
 		// Create session
 		await auth.createSession(event, userId);

--- a/src/routes/(app)/(minimal)/set-password/+page.svelte
+++ b/src/routes/(app)/(minimal)/set-password/+page.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+
+	import { consumeSignupTracking } from '$lib/client/plausible';
 	import { SetPasswordPage } from '$lib/components/page';
 
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
+
+	// New users land here right after signup — fire the one-off Signup event.
+	onMount(consumeSignupTracking);
 </script>
 
 <SetPasswordPage


### PR DESCRIPTION
## What

Adds a Plausible **`Signup`** event, fired once when a brand-new user is created, via both signup paths (email/OTP and Google OAuth), with `method` (`email` | `google`) and `whiteLabelDomain` props — extending the existing `SecretCreation` tracking.

## How

User creation happens server-side behind a redirect, so:

1. The server sets a short-lived, client-readable `signup-tracking` cookie (value = method) **only when the user is new** — in both `verifyEmailVerificationCode` and the Google OAuth callback.
2. The **set-password page** (where both new-user flows land — a brand-new user has neither password nor encryption) reads the cookie on mount via `consumeSignupTracking()`, fires the event once, and clears the cookie.

The reader lives on that specific page rather than the global layout, so it doesn't run on every navigation.

Reliable new-user detection was needed: `createOrUpdateUser` now computes `isNewUser` **before** the upsert and returns it.

## Bonus fix

`welcomeNewUser` determined `isNewUser` by calling `checkIfUserExists` **after** `createOrUpdateUser` had already inserted the row — so it was always `false`, and the welcome email + Resend audience add **never ran for new users**. It now takes the reliable flag from `createOrUpdateUser` at both call sites.

## Verification

- `pnpm check`: no errors in touched files.
- Browser: planted the `signup-tracking` cookie → loaded an `(app)` page → captured `POST plausible.io/api/event` with `n: "Signup"`, `p: { method, whiteLabelDomain }` → cookie consumed (no re-fire). The `consumeSignupTracking` helper was also exercised directly (fires with cookie present, no-ops when absent).
- The `welcomeNewUser` fix is server-side (Resend API + email) and not exercisable in preview; verified by code inspection — `isNewUser` is computed pre-upsert and threaded through.

## Notes

- **White-label scope:** white-label layouts don't initialize Plausible at all today, so this covers the main app, where both signup flows redirect. The cookie is set server-side regardless, so extending to white-label later is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)