### PR TITLE
fix(secret-response): preserve file attachment fields on submit

### DIFF
--- a/src/lib/components/forms/secret-response-form.svelte
+++ b/src/lib/components/forms/secret-response-form.svelte
@@ -80,16 +80,28 @@
 				// Generate a random AES key for this response
 				const aesKey = await generateAESKey();
 
-				// Wrap the AES key with the RSA public key
-				$formData.wrappedResponseKey = await wrapAESKeyWithRSA(aesKey, rsaPublicKey);
+				// Build the payload as a plain object. We must NOT mutate $formData
+				// field-by-field across awaits: superForm re-syncs the proxy on each
+				// await boundary, which drops some writes (browser-dependent, e.g. the
+				// file/meta fields go missing in Firefox). See secret-form.svelte.
+				const payload: SecretResponseFormSchema = {
+					requestIdHash,
+					// Wrap the AES key with the RSA public key
+					wrappedResponseKey: await wrapAESKeyWithRSA(aesKey, rsaPublicKey),
+					// Encrypt metadata with the same AES key
+					encryptedResponseMeta: await encryptResponseContent(
+						JSON.stringify({ type: hasFile ? 'file' : 'text' }),
+						aesKey
+					)
+				};
 
 				if (hasText) {
-					$formData.encryptedResponseContent = await encryptResponseContent(responseText, aesKey);
+					payload.encryptedResponseContent = await encryptResponseContent(responseText, aesKey);
 				}
 
 				if (hasFile && signingKeyPair) {
 					// Pack the file password + reference + meta into the E2E envelope
-					$formData.encryptedResponseFile = await encryptResponseContent(
+					payload.encryptedResponseFile = await encryptResponseContent(
 						JSON.stringify({
 							fileKey,
 							fileReference: JSON.parse(fileContent),
@@ -97,16 +109,13 @@
 						}),
 						aesKey
 					);
-					$formData.responseFilePublicKey = await exportPublicKey(signingKeyPair.publicKey);
+					payload.responseFilePublicKey = await exportPublicKey(signingKeyPair.publicKey);
 				}
 
-				// Encrypt metadata with the same AES key
-				$formData.encryptedResponseMeta = await encryptResponseContent(
-					JSON.stringify({ type: hasFile ? 'file' : 'text' }),
-					aesKey
-				);
-
-				jsonData($formData);
+				// Single synchronous assignment so client-side validation sees the full
+				// payload, then post it.
+				$formData = payload;
+				jsonData(payload);
 			} catch {
 				$message = {
 					status: 'error',


### PR DESCRIPTION
## Problem

File attachments silently disappear from secret responses in **Firefox**. Comparing the devalue payloads of two response submits, the broken one has `encryptedResponseMeta: -1` and `encryptedResponseFile: -1` (devalue's encoding for `undefined`) while `responseFilePublicKey` survived — even though all three are written in the same `if` block.

## Root cause

`onSubmit` in `secret-response-form.svelte` built the payload by mutating the superForm `$formData` proxy **field-by-field across `await` boundaries**, then posted the proxy via `jsonData($formData)`. Each `await` yields to the event loop, where superForm re-syncs its form store from an earlier snapshot, clobbering some of the just-written fields. Which fields survive depends on microtask scheduling — which differs between Chrome and Firefox, producing the browser-specific symptom. The field ordering confirms it's a race, not a logic error: `responseFilePublicKey` (written *after* `encryptedResponseFile`, same block) survived while the file/meta did not.

## Fix

Build a plain local `payload` object across the awaits (no proxy involved), then do a single synchronous `$formData = payload` followed by `jsonData(payload)`. This matches the proven pattern already used in `secret-form.svelte`. The sync assignment also keeps the client-side `.refine` (content-or-file required) validation working.

## Verification

- `pnpm check` introduces no new errors in the file.
- Not browser-verified: the bug is Firefox-specific and the preview tooling drives Chromium, where the race doesn't manifest; a full end-to-end check also needs auth + a created secret-request + S3 upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)