### PR TITLE
fix(i18n): sync glad_true_lark_note placeholders across locales

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -753,7 +753,7 @@
 	"keen_bright_fox_peek": "Antwort ansehen",
 	"swift_slim_deer_turn": "Zurück zu den Anfragen",
 	"safe_deep_wolf_read": "Geheimnisantwort",
-	"glad_true_lark_note": "Antwort erhalten am {dateTime}",
+	"glad_true_lark_note": "Antwort erhalten am {receivedAt}. Verschwindet am {destructionDate}.",
 	"red_sharp_viper_fail": "Entschlüsselung fehlgeschlagen",
 	"slow_calm_newt_spin": "Antwort wird entschlüsselt...",
 	"brave_kind_lamb_give": "Geheimnis übermitteln",

--- a/messages/es.json
+++ b/messages/es.json
@@ -753,7 +753,7 @@
 	"keen_bright_fox_peek": "Ver respuesta",
 	"swift_slim_deer_turn": "Volver a solicitudes",
 	"safe_deep_wolf_read": "Respuesta secreta",
-	"glad_true_lark_note": "Respuesta recibida el {dateTime}",
+	"glad_true_lark_note": "Respuesta recibida el {receivedAt}. Desaparece el {destructionDate}.",
 	"red_sharp_viper_fail": "Fallo en el descifrado",
 	"slow_calm_newt_spin": "Descifrando respuesta...",
 	"brave_kind_lamb_give": "Enviar un secreto",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -753,7 +753,7 @@
 	"keen_bright_fox_peek": "Afficher la réponse",
 	"swift_slim_deer_turn": "Retour aux demandes",
 	"safe_deep_wolf_read": "Réponse secrète",
-	"glad_true_lark_note": "Réponse reçue le {dateTime}",
+	"glad_true_lark_note": "Réponse reçue le {receivedAt}. Disparaît le {destructionDate}.",
 	"red_sharp_viper_fail": "Échec du déchiffrement",
 	"slow_calm_newt_spin": "Déchiffrement de la réponse...",
 	"brave_kind_lamb_give": "Soumettre un secret",

--- a/messages/no.json
+++ b/messages/no.json
@@ -753,7 +753,7 @@
 	"keen_bright_fox_peek": "Vis svar",
 	"swift_slim_deer_turn": "Tilbake til forespørsler",
 	"safe_deep_wolf_read": "Hemmelig svar",
-	"glad_true_lark_note": "Svar mottatt {dateTime}",
+	"glad_true_lark_note": "Svar mottatt {receivedAt}. Forsvinner {destructionDate}.",
 	"red_sharp_viper_fail": "Dekryptering mislyktes",
 	"slow_calm_newt_spin": "Dekrypterer svar …",
 	"brave_kind_lamb_give": "Secret Request",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -753,7 +753,7 @@
 	"keen_bright_fox_peek": "Просмотреть ответ",
 	"swift_slim_deer_turn": "Назад к запросам",
 	"safe_deep_wolf_read": "Секретный ответ",
-	"glad_true_lark_note": "Ответ получен {dateTime}",
+	"glad_true_lark_note": "Ответ получен {receivedAt}. Исчезнет {destructionDate}.",
 	"red_sharp_viper_fail": "Ошибка дешифрования",
 	"slow_calm_newt_spin": "Дешифровка ответа...",
 	"brave_kind_lamb_give": "Отправить секрет",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -753,7 +753,7 @@
 	"keen_bright_fox_peek": "Visa svar",
 	"swift_slim_deer_turn": "Tillbaka till förfrågningar",
 	"safe_deep_wolf_read": "Hemligt svar",
-	"glad_true_lark_note": "Svar mottaget den {dateTime}",
+	"glad_true_lark_note": "Svar mottaget den {receivedAt}. Försvinner den {destructionDate}.",
 	"red_sharp_viper_fail": "Dekryptering misslyckades",
 	"slow_calm_newt_spin": "Dekrypterar svar...",
 	"brave_kind_lamb_give": "Secret Request",


### PR DESCRIPTION
## Problem

The "Response received on … Vanishes on …" message (`glad_true_lark_note`) rendered **`undefined`** for users in some locales, e.g. German showed `Antwort erhalten am undefined`.

## Root cause

Translation drift, not a component bug. The English source was updated to use two placeholders (`{receivedAt}`, `{destructionDate}`), but six locale files still referenced the obsolete `{dateTime}`:

| Locale | Before | After |
|--------|--------|-------|
| de | `Antwort erhalten am {dateTime}` | `Antwort erhalten am {receivedAt}. Verschwindet am {destructionDate}.` |
| fr | `Réponse reçue le {dateTime}` | `Réponse reçue le {receivedAt}. Disparaît le {destructionDate}.` |
| es | `Respuesta recibida el {dateTime}` | `Respuesta recibida el {receivedAt}. Desaparece el {destructionDate}.` |
| ru | `Ответ получен {dateTime}` | `Ответ получен {receivedAt}. Исчезнет {destructionDate}.` |
| sv | `Svar mottaget den {dateTime}` | `Svar mottaget den {receivedAt}. Försvinner den {destructionDate}.` |
| no | `Svar mottatt {dateTime}` | `Svar mottatt {receivedAt}. Forsvinner {destructionDate}.` |

Two effects:
- **Runtime:** Paraglide renders the active locale's string. Those locales interpolated `{dateTime}`, which the call site at `request-response-viewer.svelte:168` never passes → literal `undefined`; the `receivedAt`/`destructionDate` values it did pass were dropped.
- **Types:** Paraglide types a message as the *union of placeholders across all locales*, so the generated input type carried a stale `dateTime` param. English-only checks never caught it.

## Fix

Re-translate the six drifted locales to the current two-placeholder form. The generated `src/lib/paraglide/` output (git-ignored) self-heals on the next build and the stale `dateTime` param disappears. No component or `formatDateTime` change needed — the existing `{#if data.request.respondedAt && destructionDate}` guard already keeps the passed values non-null.

## Notes

- Deviated from the standard `/translate-keys` flow (which only fills *missing* keys) since these keys existed but were stale — surgically replaced only the single drifted line per file.
- Unrelated, but flagging: `dev`/`build` currently fail in a fresh checkout with `ERR_MODULE_NOT_FOUND: kysely` (dangling symlink under `@lix-js/sdk`); a `pnpm install` likely fixes it. Could not run a live render check because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)