### PR TITLE
fix(csp): allow mode-watcher inline script via hash

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -29,6 +29,11 @@ const config = {
 				'default-src': ['none'],
 				'script-src': [
 					'self',
+					// Hash of mode-watcher's inline anti-FOUC `setInitialMode` script in <head>.
+					// SvelteKit doesn't nonce library-injected head scripts, so it must be
+					// allowlisted by hash. Re-check this if mode-watcher is upgraded or its
+					// <ModeWatcher> props change (the inline script content would change).
+					'sha256-cIZByCqcmZEwY5l704mu2OYBzfdBwMjhGZvxBc2yUeE=',
 					'https://js.stripe.com',
 					'https://vercel.live',
 					'https://www.google.com',


### PR DESCRIPTION
## Problem

Every page logged a CSP violation:

> Executing inline script violates the following Content Security Policy directive 'script-src 'self' … 'nonce-…''.

The blocked script is **mode-watcher's** anti-FOUC `setInitialMode` IIFE, rendered into `<head>` by `<ModeWatcher>` in `src/routes/+layout.svelte`. SvelteKit's `csp: { mode: 'auto' }` only applies its per-request nonce to scripts **it** generates — not to library-injected `<head>` scripts — so this one had no nonce and was rejected site-wide.

(The FAQ `application/ld+json` block is non-executable, so it was never the cause.)

## Why the usual fixes don't apply

- `'unsafe-inline'` is **ignored by browsers when a nonce is present** (CSP2+), and SvelteKit always emits a nonce in `auto` mode.
- The script is injected at runtime, so it can't receive SvelteKit's nonce.

The script's bytes are deterministic, so the correct fix is a **CSP hash** — exactly what the browser already reported.

## Fix

Add `'sha256-cIZByCqcmZEwY5l704mu2OYBzfdBwMjhGZvxBc2yUeE='` to `script-src` in `svelte.config.js`. (SvelteKit auto-quotes sources matching `^sha\d\d\d-`, so it's written unquoted; hash + nonce coexist — the browser allows a script matching *either*.)

## Verification (running dev server)

- CSP response header now includes the hash next to the nonce: `script-src 'self' 'sha256-cIZByCqc…' … 'nonce-…'`
- The inline script **executes** — `<html>` gets `style="color-scheme: …"` set by `setInitialMode`.
- Console: **no CSP violations**.

## Caveat

If `mode-watcher` is upgraded or `<ModeWatcher>` props change, the inline script's bytes change and the hash must be regenerated (the browser prints the new `sha256-…`). A code comment notes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)