### PR TITLE
feat(analytics): track Subscription event with subscriptionTier

### DIFF
--- a/src/lib/client/plausible.ts
+++ b/src/lib/client/plausible.ts
@@ -33,3 +33,16 @@ export const consumeSignupTracking = () => {
 		props: { method, whiteLabelDomain: window.location.host }
 	});
 };
+
+/**
+ * Fire a Plausible "Subscription" event tagged with the subscribed tier. Call on
+ * mount of the post-checkout landing page (upgrade-success), which only renders
+ * after a resolvable Stripe checkout.
+ */
+export const trackSubscription = (subscriptionTier: string) => {
+	if (!plausible) return;
+
+	plausible.trackEvent('Subscription', {
+		props: { subscriptionTier, whiteLabelDomain: window.location.host }
+	});
+};

--- a/src/routes/(app)/(default)/upgrade-success/+page.svelte
+++ b/src/routes/(app)/(default)/upgrade-success/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+
 	import { TRIAL_PERIOD_DAYS } from '$lib/client/constants';
+	import { trackSubscription } from '$lib/client/plausible';
 	import Page from '$lib/components/page/default-page.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import Container from '$lib/components/ui/container/container.svelte';
@@ -12,6 +15,8 @@
 	const plan = $derived(getPlanContents(data.planName));
 	const PlanIcon = $derived(plan.icon);
 	const ctaHref = $derived(localizeHref(plan.isOrgPlan ? '/account/organization' : '/account'));
+
+	onMount(() => trackSubscription(data.planName));
 </script>
 
 <Page


### PR DESCRIPTION
## What

Adds a Plausible **Subscription** event with a `subscriptionTier` property, fired on the upgrade-success page after a completed Stripe checkout.

## Details

- New `trackSubscription(subscriptionTier)` helper in `src/lib/client/plausible.ts`, mirroring the existing `consumeSignupTracking` pattern.
- Called on mount in `upgrade-success/+page.svelte` with `data.planName` — the resolved tier (`Confidential`, `Secret`, `Top Secret`, `Secret Service`, `Top Secret Service`). This matches the `subscriptionTier` prop values already used by the `SecretCreation` event.
- The upgrade-success page only renders after a resolvable Stripe checkout (its `load` redirects away otherwise), so the event maps cleanly to a completed subscription.

## Notes

- No exactly-once guard: a page reload would re-fire the event. Unlike `Signup` (which needed a cookie to survive the OAuth redirect), the checkout URL is transient — matching the codebase's non-paranoid stance for other events. Can add a once-only cookie guard if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)