### PR TITLE
feat: promote Chrome browser extension

### DIFF
--- a/messages/da.json
+++ b/messages/da.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Du har modtaget et svar på følgende anmodning:",
 	"gold_tidy_crane_expiry": "Du har {retentionPeriod} dage til at se svaret. Derefter er det væk for altid.",
 	"polite_bad_parrot_scold": "Forsvinder",
-	"calm_brave_otter_read": "Læs vores privatlivspolitik"
+	"calm_brave_otter_read": "Læs vores privatlivspolitik",
+	"browser_extension_label": "Browserudvidelse",
+	"browser_extension_tooltip": "Del en hemmelighed direkte fra din browser. Kræver en API-nøgle.",
+	"browser_extension_faq_heading": "Findes der en browserudvidelse?",
+	"browser_extension_faq_body": "Ja! Installer [scrt.link-browserudvidelsen](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) til Chrome for at oprette hemmelige links uden at forlade din nuværende fane. Udvidelsen kommunikerer med vores offentlige API, så en **[Top Secret](/pricing)**-plan med en API-nøgle er påkrævet."
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Du hast eine Antwort auf die folgende Anfrage erhalten:",
 	"gold_tidy_crane_expiry": "Du hast {retentionPeriod} Tage Zeit, die Antwort anzusehen. Danach ist sie für immer verschwunden.",
 	"polite_bad_parrot_scold": "Verschwindet",
-	"calm_brave_otter_read": "Lies unsere Datenschutzerklärung"
+	"calm_brave_otter_read": "Lies unsere Datenschutzerklärung",
+	"browser_extension_label": "Browser-Erweiterung",
+	"browser_extension_tooltip": "Teile ein Geheimnis direkt aus deinem Browser. Erfordert einen API-Schlüssel.",
+	"browser_extension_faq_heading": "Gibt es eine Browser-Erweiterung?",
+	"browser_extension_faq_body": "Ja! Installiere die [scrt.link Browser-Erweiterung](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) für Chrome, um Geheimlinks zu erstellen, ohne deinen aktuellen Tab zu verlassen. Die Erweiterung kommuniziert mit unserer öffentlichen API, daher ist ein **[Top Secret](/pricing)**-Tarif mit einem API-Schlüssel erforderlich."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "You have received a response to the following request:",
 	"gold_tidy_crane_expiry": "You have {retentionPeriod} days to view the response. After that, it's gone for good.",
 	"polite_bad_parrot_scold": "Vanishes",
-	"calm_brave_otter_read": "Read our privacy policy"
+	"calm_brave_otter_read": "Read our privacy policy",
+	"browser_extension_label": "Browser Extension",
+	"browser_extension_tooltip": "Share a secret straight from your browser. Requires an API key.",
+	"browser_extension_faq_heading": "Is there a browser extension?",
+	"browser_extension_faq_body": "Yes! Install the [scrt.link browser extension](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) for Chrome to create secret links without leaving your current tab. The extension talks to our public API, so a **[Top Secret](/pricing)** plan with an API key is required."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Has recibido una respuesta a la siguiente solicitud:",
 	"gold_tidy_crane_expiry": "Tienes {retentionPeriod} días para ver la respuesta. Después, desaparecerá para siempre.",
 	"polite_bad_parrot_scold": "Desaparece",
-	"calm_brave_otter_read": "Lee nuestra política de privacidad"
+	"calm_brave_otter_read": "Lee nuestra política de privacidad",
+	"browser_extension_label": "Extensión del navegador",
+	"browser_extension_tooltip": "Comparte un secreto directamente desde tu navegador. Requiere una clave API.",
+	"browser_extension_faq_heading": "¿Hay una extensión del navegador?",
+	"browser_extension_faq_body": "¡Sí! Instala la [extensión de navegador de scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) para Chrome para crear enlaces secretos sin salir de tu pestaña actual. La extensión se comunica con nuestra API pública, por lo que se requiere un plan **[Top Secret](/pricing)** con una clave API."
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Vous avez reçu une réponse à la demande suivante :",
 	"gold_tidy_crane_expiry": "Vous avez {retentionPeriod} jours pour consulter la réponse. Après cela, elle disparaît pour toujours.",
 	"polite_bad_parrot_scold": "Disparaît",
-	"calm_brave_otter_read": "Lire notre politique de confidentialité"
+	"calm_brave_otter_read": "Lire notre politique de confidentialité",
+	"browser_extension_label": "Extension de navigateur",
+	"browser_extension_tooltip": "Partagez un secret directement depuis votre navigateur. Nécessite une clé API.",
+	"browser_extension_faq_heading": "Existe-t-il une extension de navigateur ?",
+	"browser_extension_faq_body": "Oui ! Installez l'[extension de navigateur scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) pour Chrome afin de créer des liens secrets sans quitter votre onglet actuel. L'extension communique avec notre API publique, une offre **[Top Secret](/pricing)** avec une clé API est donc requise."
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Hai ricevuto una risposta alla seguente richiesta:",
 	"gold_tidy_crane_expiry": "Hai {retentionPeriod} giorni per visualizzare la risposta. Dopo, sparirà per sempre.",
 	"polite_bad_parrot_scold": "Scompare",
-	"calm_brave_otter_read": "Leggi la nostra informativa sulla privacy"
+	"calm_brave_otter_read": "Leggi la nostra informativa sulla privacy",
+	"browser_extension_label": "Estensione del browser",
+	"browser_extension_tooltip": "Condividi un segreto direttamente dal tuo browser. Richiede una chiave API.",
+	"browser_extension_faq_heading": "Esiste un'estensione del browser?",
+	"browser_extension_faq_body": "Sì! Installa l'[estensione per browser scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) per Chrome per creare link segreti senza lasciare la scheda corrente. L'estensione comunica con la nostra API pubblica, quindi è necessario un piano **[Top Secret](/pricing)** con una chiave API."
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "以下のリクエストへの回答を受け取りました：",
 	"gold_tidy_crane_expiry": "回答を確認できる期間は{retentionPeriod}日間です。それ以降は完全に削除されます。",
 	"polite_bad_parrot_scold": "消える",
-	"calm_brave_otter_read": "プライバシーポリシーを読む"
+	"calm_brave_otter_read": "プライバシーポリシーを読む",
+	"browser_extension_label": "ブラウザ拡張機能",
+	"browser_extension_tooltip": "ブラウザから直接シークレットを共有できます。API キーが必要です。",
+	"browser_extension_faq_heading": "ブラウザ拡張機能はありますか？",
+	"browser_extension_faq_body": "はい！Chrome 用の [scrt.link ブラウザ拡張機能](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) をインストールすると、現在のタブを離れることなくシークレットリンクを作成できます。この拡張機能は当社の公開 API と連携するため、API キー付きの **[Top Secret](/pricing)** プランが必要です。"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Je hebt een reactie ontvangen op het volgende verzoek:",
 	"gold_tidy_crane_expiry": "Je hebt {retentionPeriod} dagen om de reactie te bekijken. Daarna is hij voorgoed weg.",
 	"polite_bad_parrot_scold": "Verdwijnt",
-	"calm_brave_otter_read": "Lees ons privacybeleid"
+	"calm_brave_otter_read": "Lees ons privacybeleid",
+	"browser_extension_label": "Browserextensie",
+	"browser_extension_tooltip": "Deel een geheim rechtstreeks vanuit je browser. Vereist een API-sleutel.",
+	"browser_extension_faq_heading": "Is er een browserextensie?",
+	"browser_extension_faq_body": "Ja! Installeer de [scrt.link-browserextensie](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) voor Chrome om geheime links te maken zonder je huidige tabblad te verlaten. De extensie communiceert met onze openbare API, dus een **[Top Secret](/pricing)**-abonnement met een API-sleutel is vereist."
 }

--- a/messages/no.json
+++ b/messages/no.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Du har mottatt et svar på følgende forespørsel:",
 	"gold_tidy_crane_expiry": "Du har {retentionPeriod} dager på å se svaret. Etter det er det borte for godt.",
 	"polite_bad_parrot_scold": "Forsvinner",
-	"calm_brave_otter_read": "Les personvernerklæringen vår"
+	"calm_brave_otter_read": "Les personvernerklæringen vår",
+	"browser_extension_label": "Nettleserutvidelse",
+	"browser_extension_tooltip": "Del en hemmelighet direkte fra nettleseren din. Krever en API-nøkkel.",
+	"browser_extension_faq_heading": "Finnes det en nettleserutvidelse?",
+	"browser_extension_faq_body": "Ja! Installer [scrt.link-nettleserutvidelsen](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) for Chrome for å opprette hemmelige lenker uten å forlate den gjeldende fanen. Utvidelsen kommuniserer med vårt offentlige API, så en **[Top Secret](/pricing)**-plan med en API-nøkkel kreves."
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Otrzymałeś odpowiedź na następujące żądanie:",
 	"gold_tidy_crane_expiry": "Masz {retentionPeriod} dni na wyświetlenie odpowiedzi. Po tym czasie zostanie ona trwale usunięta.",
 	"polite_bad_parrot_scold": "Znika",
-	"calm_brave_otter_read": "Przeczytaj naszą politykę prywatności"
+	"calm_brave_otter_read": "Przeczytaj naszą politykę prywatności",
+	"browser_extension_label": "Rozszerzenie przeglądarki",
+	"browser_extension_tooltip": "Udostępniaj sekret bezpośrednio z przeglądarki. Wymaga klucza API.",
+	"browser_extension_faq_heading": "Czy jest dostępne rozszerzenie przeglądarki?",
+	"browser_extension_faq_body": "Tak! Zainstaluj [rozszerzenie przeglądarki scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) dla Chrome, aby tworzyć sekretne linki bez opuszczania bieżącej karty. Rozszerzenie komunikuje się z naszym publicznym API, dlatego wymagany jest plan **[Top Secret](/pricing)** z kluczem API."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Você recebeu uma resposta para a seguinte solicitação:",
 	"gold_tidy_crane_expiry": "Você tem {retentionPeriod} dias para visualizar a resposta. Depois disso, ela será apagada para sempre.",
 	"polite_bad_parrot_scold": "Desaparece",
-	"calm_brave_otter_read": "Leia a nossa política de privacidade"
+	"calm_brave_otter_read": "Leia a nossa política de privacidade",
+	"browser_extension_label": "Extensão do navegador",
+	"browser_extension_tooltip": "Partilhe um segredo diretamente do seu navegador. Requer uma chave API.",
+	"browser_extension_faq_heading": "Existe uma extensão do navegador?",
+	"browser_extension_faq_body": "Sim! Instale a [extensão de navegador scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) para o Chrome para criar links secretos sem sair do seu separador atual. A extensão comunica com a nossa API pública, por isso é necessário um plano **[Top Secret](/pricing)** com uma chave API."
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Вы получили ответ на следующий запрос:",
 	"gold_tidy_crane_expiry": "У вас есть {retentionPeriod} дней, чтобы просмотреть ответ. После этого он исчезнет навсегда.",
 	"polite_bad_parrot_scold": "Исчезает",
-	"calm_brave_otter_read": "Читать нашу политику конфиденциальности"
+	"calm_brave_otter_read": "Читать нашу политику конфиденциальности",
+	"browser_extension_label": "Расширение для браузера",
+	"browser_extension_tooltip": "Делитесь секретом прямо из браузера. Требуется ключ API.",
+	"browser_extension_faq_heading": "Есть ли расширение для браузера?",
+	"browser_extension_faq_body": "Да! Установите [расширение scrt.link для браузера](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) в Chrome, чтобы создавать секретные ссылки, не покидая текущую вкладку. Расширение работает через наш публичный API, поэтому требуется тариф **[Top Secret](/pricing)** с ключом API."
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "Du har fått ett svar på följande förfrågan:",
 	"gold_tidy_crane_expiry": "Du har {retentionPeriod} dagar på dig att se svaret. Därefter är det borta för gott.",
 	"polite_bad_parrot_scold": "Försvinner",
-	"calm_brave_otter_read": "Läs vår integritetspolicy"
+	"calm_brave_otter_read": "Läs vår integritetspolicy",
+	"browser_extension_label": "Webbläsartillägg",
+	"browser_extension_tooltip": "Dela en hemlighet direkt från din webbläsare. Kräver en API-nyckel.",
+	"browser_extension_faq_heading": "Finns det ett webbläsartillägg?",
+	"browser_extension_faq_body": "Ja! Installera [scrt.link-webbläsartillägget](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) för Chrome för att skapa hemliga länkar utan att lämna din aktuella flik. Tillägget kommunicerar med vårt publika API, så en **[Top Secret](/pricing)**-plan med en API-nyckel krävs."
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -993,5 +993,9 @@
 	"gold_tidy_crane_body": "您已收到以下请求的回复：",
 	"gold_tidy_crane_expiry": "您有 {retentionPeriod} 天时间查看回复。逾期后将永久删除。",
 	"polite_bad_parrot_scold": "消失",
-	"calm_brave_otter_read": "阅读我们的隐私政策"
+	"calm_brave_otter_read": "阅读我们的隐私政策",
+	"browser_extension_label": "浏览器扩展",
+	"browser_extension_tooltip": "直接从浏览器分享秘密。需要 API 密钥。",
+	"browser_extension_faq_heading": "有浏览器扩展吗？",
+	"browser_extension_faq_body": "有！为 Chrome 安装 [scrt.link 浏览器扩展](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh)，即可在不离开当前标签页的情况下创建秘密链接。该扩展通过我们的公共 API 通信，因此需要带有 API 密钥的 **[Top Secret](/pricing)** 套餐。"
 }

--- a/src/lib/data/app.ts
+++ b/src/lib/data/app.ts
@@ -22,6 +22,8 @@ export const emailSupport = 'support@scrt.link';
 export const emailNoReply = 'no-reply@scrt.link';
 export const uptimerobotUrl = 'https://stats.uptimerobot.com/v5yqDuEr5z';
 export const githubUrl = 'https://github.com/stophecom/scrt-link-v2';
+export const browserExtensionUrl =
+	'https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh';
 export const blueskyUrl = 'https://bsky.app/profile/scrt.link';
 export const linkedinUrl = 'https://www.linkedin.com/company/santihans';
 

--- a/src/lib/data/faq/product.ts
+++ b/src/lib/data/faq/product.ts
@@ -13,6 +13,12 @@ const product = () => [
 		category: 'product',
 		heading: m.dry_fun_ant_sail(),
 		body: m.crazy_dark_tuna_stop()
+	},
+	{
+		id: 'browser-extension',
+		category: 'product',
+		heading: m.browser_extension_faq_heading(),
+		body: m.browser_extension_faq_body()
 	}
 ];
 

--- a/src/lib/data/menu.ts
+++ b/src/lib/data/menu.ts
@@ -9,7 +9,7 @@ import {
 
 import { m } from '$lib/paraglide/messages.js';
 
-import { githubUrl } from './app';
+import { browserExtensionUrl, githubUrl } from './app';
 
 export const secretMenu = () => [
 	{
@@ -61,6 +61,11 @@ export const productMenu = () => [
 	{
 		href: '/cli',
 		label: 'CLI'
+	},
+	{
+		href: browserExtensionUrl,
+		externalLink: true,
+		label: 'Chrome Extension'
 	},
 	{
 		href: 'https://deepwiki.com/stophecom/scrt-link-v2',

--- a/src/lib/data/plans.ts
+++ b/src/lib/data/plans.ts
@@ -94,6 +94,7 @@ export const plans = () => [
 			{ label: m.new_still_dingo_create({ limit: formatBytes(100 * GB) }) },
 			{ label: m.active_mellow_swan_list({ amount: 30 }) },
 			{ label: m.blue_jumpy_shell_climb(), tooltip: m.keen_rose_ant_zoom() },
+			{ label: m.browser_extension_label(), tooltip: m.browser_extension_tooltip() },
 			{ label: m.still_busy_starfish_dare() }
 		],
 		limits: {

--- a/src/routes/(app)/(default)/pricing/comparison-table.svelte
+++ b/src/routes/(app)/(default)/pricing/comparison-table.svelte
@@ -36,6 +36,7 @@
 		{ label: m.kind_sharp_owl_record(), values: [false, true, true] },
 		{ label: m.warm_dark_owl_gaze(), values: ['24 hours', '7 days', '30 days'] },
 		{ label: m.few_away_tadpole_hope(), values: [false, false, true] },
+		{ label: m.browser_extension_label(), values: [false, false, true] },
 		{
 			label: m.keen_warm_eel_swim(),
 			values: ['-', m.tired_new_mantis_buy(), m.still_busy_starfish_dare()]
@@ -52,6 +53,7 @@
 		{ label: m.kind_sharp_owl_record(), values: [true, true] },
 		{ label: m.warm_dark_owl_gaze(), values: ['7 days', '30 days'] },
 		{ label: m.few_away_tadpole_hope(), values: [true, true] },
+		{ label: m.browser_extension_label(), values: [true, true] },
 		{ label: m.bold_slim_ram_roam(), values: [true, true] },
 		{ label: m.wild_inner_fox_honor(), values: [true, true] },
 		{ label: m.bold_stat_log_feat(), values: [false, true] },


### PR DESCRIPTION
## Summary

Promotes the new [scrt.link Chrome extension](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) across the marketing surfaces of the site.

## Changes

- **Store URL** — added `browserExtensionUrl` constant in `src/lib/data/app.ts`.
- **Top Secret plan** — "Browser Extension" listed as a feature on the plan card (with an API-key tooltip) and added to the personal + business comparison tables.
- **FAQ** — new Product entry ("Is there a browser extension?") noting a Top Secret plan with an API key is required, linking to the store and `/pricing`.
- **Footer** — "Chrome Extension" link in the product menu (opens in a new tab).
- **i18n** — new keys added to `messages/en.json` and translated into all 13 other locales. Footer label is an intentional plain string (not translated).

## Verification

- Server-rendered output confirmed on `/pricing`, `/faq`, and the footer against the dev server.
- `pnpm lint` passes. `pnpm check` shows only pre-existing type errors in unrelated UI components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)