### PR TITLE
feat(marketing): promote Firefox browser extension

### DIFF
--- a/messages/da.json
+++ b/messages/da.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Browserudvidelse",
 	"browser_extension_tooltip": "Del en hemmelighed direkte fra din browser. Kræver en API-nøgle.",
 	"browser_extension_faq_heading": "Findes der en browserudvidelse?",
-	"browser_extension_faq_body": "Ja! Installer [scrt.link-browserudvidelsen](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) til Chrome for at oprette hemmelige links uden at forlade din nuværende fane. Udvidelsen kommunikerer med vores offentlige API, så en **[Top Secret](/pricing)**-plan med en API-nøgle er påkrævet."
+	"browser_extension_faq_body": "Ja! Installer scrt.link-browserudvidelsen til [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) eller [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) for at oprette hemmelige links uden at forlade din nuværende fane. Udvidelsen kommunikerer med vores offentlige API, så en **[Top Secret](/pricing)**-plan med en API-nøgle er påkrævet."
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Browser-Erweiterung",
 	"browser_extension_tooltip": "Teile ein Geheimnis direkt aus deinem Browser. Erfordert einen API-Schlüssel.",
 	"browser_extension_faq_heading": "Gibt es eine Browser-Erweiterung?",
-	"browser_extension_faq_body": "Ja! Installiere die [scrt.link Browser-Erweiterung](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) für Chrome, um Geheimlinks zu erstellen, ohne deinen aktuellen Tab zu verlassen. Die Erweiterung kommuniziert mit unserer öffentlichen API, daher ist ein **[Top Secret](/pricing)**-Tarif mit einem API-Schlüssel erforderlich."
+	"browser_extension_faq_body": "Ja! Installiere die scrt.link Browser-Erweiterung für [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) oder [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/), um Geheimlinks zu erstellen, ohne deinen aktuellen Tab zu verlassen. Die Erweiterung kommuniziert mit unserer öffentlichen API, daher ist ein **[Top Secret](/pricing)**-Tarif mit einem API-Schlüssel erforderlich."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Browser Extension",
 	"browser_extension_tooltip": "Share a secret straight from your browser. Requires an API key.",
 	"browser_extension_faq_heading": "Is there a browser extension?",
-	"browser_extension_faq_body": "Yes! Install the [scrt.link browser extension](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) for Chrome to create secret links without leaving your current tab. The extension talks to our public API, so a **[Top Secret](/pricing)** plan with an API key is required."
+	"browser_extension_faq_body": "Yes! Install the scrt.link browser extension for [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) to create secret links without leaving your current tab. The extension talks to our public API, so a **[Top Secret](/pricing)** plan with an API key is required."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Extensión del navegador",
 	"browser_extension_tooltip": "Comparte un secreto directamente desde tu navegador. Requiere una clave API.",
 	"browser_extension_faq_heading": "¿Hay una extensión del navegador?",
-	"browser_extension_faq_body": "¡Sí! Instala la [extensión de navegador de scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) para Chrome para crear enlaces secretos sin salir de tu pestaña actual. La extensión se comunica con nuestra API pública, por lo que se requiere un plan **[Top Secret](/pricing)** con una clave API."
+	"browser_extension_faq_body": "¡Sí! Instala la extensión de navegador de scrt.link para [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) o [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) para crear enlaces secretos sin salir de tu pestaña actual. La extensión se comunica con nuestra API pública, por lo que se requiere un plan **[Top Secret](/pricing)** con una clave API."
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Extension de navigateur",
 	"browser_extension_tooltip": "Partagez un secret directement depuis votre navigateur. Nécessite une clé API.",
 	"browser_extension_faq_heading": "Existe-t-il une extension de navigateur ?",
-	"browser_extension_faq_body": "Oui ! Installez l'[extension de navigateur scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) pour Chrome afin de créer des liens secrets sans quitter votre onglet actuel. L'extension communique avec notre API publique, une offre **[Top Secret](/pricing)** avec une clé API est donc requise."
+	"browser_extension_faq_body": "Oui ! Installez l'extension de navigateur scrt.link pour [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) ou [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) afin de créer des liens secrets sans quitter votre onglet actuel. L'extension communique avec notre API publique, une offre **[Top Secret](/pricing)** avec une clé API est donc requise."
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Estensione del browser",
 	"browser_extension_tooltip": "Condividi un segreto direttamente dal tuo browser. Richiede una chiave API.",
 	"browser_extension_faq_heading": "Esiste un'estensione del browser?",
-	"browser_extension_faq_body": "Sì! Installa l'[estensione per browser scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) per Chrome per creare link segreti senza lasciare la scheda corrente. L'estensione comunica con la nostra API pubblica, quindi è necessario un piano **[Top Secret](/pricing)** con una chiave API."
+	"browser_extension_faq_body": "Sì! Installa l'estensione per browser scrt.link per [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) o [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) per creare link segreti senza lasciare la scheda corrente. L'estensione comunica con la nostra API pubblica, quindi è necessario un piano **[Top Secret](/pricing)** con una chiave API."
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "ブラウザ拡張機能",
 	"browser_extension_tooltip": "ブラウザから直接シークレットを共有できます。API キーが必要です。",
 	"browser_extension_faq_heading": "ブラウザ拡張機能はありますか？",
-	"browser_extension_faq_body": "はい！Chrome 用の [scrt.link ブラウザ拡張機能](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) をインストールすると、現在のタブを離れることなくシークレットリンクを作成できます。この拡張機能は当社の公開 API と連携するため、API キー付きの **[Top Secret](/pricing)** プランが必要です。"
+	"browser_extension_faq_body": "はい！[Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) または [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) 用の scrt.link ブラウザ拡張機能をインストールすると、現在のタブを離れることなくシークレットリンクを作成できます。この拡張機能は当社の公開 API と連携するため、API キー付きの **[Top Secret](/pricing)** プランが必要です。"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Browserextensie",
 	"browser_extension_tooltip": "Deel een geheim rechtstreeks vanuit je browser. Vereist een API-sleutel.",
 	"browser_extension_faq_heading": "Is er een browserextensie?",
-	"browser_extension_faq_body": "Ja! Installeer de [scrt.link-browserextensie](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) voor Chrome om geheime links te maken zonder je huidige tabblad te verlaten. De extensie communiceert met onze openbare API, dus een **[Top Secret](/pricing)**-abonnement met een API-sleutel is vereist."
+	"browser_extension_faq_body": "Ja! Installeer de scrt.link-browserextensie voor [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) of [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) om geheime links te maken zonder je huidige tabblad te verlaten. De extensie communiceert met onze openbare API, dus een **[Top Secret](/pricing)**-abonnement met een API-sleutel is vereist."
 }

--- a/messages/no.json
+++ b/messages/no.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Nettleserutvidelse",
 	"browser_extension_tooltip": "Del en hemmelighet direkte fra nettleseren din. Krever en API-nøkkel.",
 	"browser_extension_faq_heading": "Finnes det en nettleserutvidelse?",
-	"browser_extension_faq_body": "Ja! Installer [scrt.link-nettleserutvidelsen](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) for Chrome for å opprette hemmelige lenker uten å forlate den gjeldende fanen. Utvidelsen kommuniserer med vårt offentlige API, så en **[Top Secret](/pricing)**-plan med en API-nøkkel kreves."
+	"browser_extension_faq_body": "Ja! Installer scrt.link-nettleserutvidelsen for [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) eller [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) for å opprette hemmelige lenker uten å forlate den gjeldende fanen. Utvidelsen kommuniserer med vårt offentlige API, så en **[Top Secret](/pricing)**-plan med en API-nøkkel kreves."
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Rozszerzenie przeglądarki",
 	"browser_extension_tooltip": "Udostępniaj sekret bezpośrednio z przeglądarki. Wymaga klucza API.",
 	"browser_extension_faq_heading": "Czy jest dostępne rozszerzenie przeglądarki?",
-	"browser_extension_faq_body": "Tak! Zainstaluj [rozszerzenie przeglądarki scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) dla Chrome, aby tworzyć sekretne linki bez opuszczania bieżącej karty. Rozszerzenie komunikuje się z naszym publicznym API, dlatego wymagany jest plan **[Top Secret](/pricing)** z kluczem API."
+	"browser_extension_faq_body": "Tak! Zainstaluj rozszerzenie przeglądarki scrt.link dla [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) lub [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/), aby tworzyć sekretne linki bez opuszczania bieżącej karty. Rozszerzenie komunikuje się z naszym publicznym API, dlatego wymagany jest plan **[Top Secret](/pricing)** z kluczem API."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Extensão do navegador",
 	"browser_extension_tooltip": "Partilhe um segredo diretamente do seu navegador. Requer uma chave API.",
 	"browser_extension_faq_heading": "Existe uma extensão do navegador?",
-	"browser_extension_faq_body": "Sim! Instale a [extensão de navegador scrt.link](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) para o Chrome para criar links secretos sem sair do seu separador atual. A extensão comunica com a nossa API pública, por isso é necessário um plano **[Top Secret](/pricing)** com uma chave API."
+	"browser_extension_faq_body": "Sim! Instale a extensão de navegador scrt.link para [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) ou [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) para criar links secretos sem sair do seu separador atual. A extensão comunica com a nossa API pública, por isso é necessário um plano **[Top Secret](/pricing)** com uma chave API."
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Расширение для браузера",
 	"browser_extension_tooltip": "Делитесь секретом прямо из браузера. Требуется ключ API.",
 	"browser_extension_faq_heading": "Есть ли расширение для браузера?",
-	"browser_extension_faq_body": "Да! Установите [расширение scrt.link для браузера](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) в Chrome, чтобы создавать секретные ссылки, не покидая текущую вкладку. Расширение работает через наш публичный API, поэтому требуется тариф **[Top Secret](/pricing)** с ключом API."
+	"browser_extension_faq_body": "Да! Установите расширение scrt.link для браузера [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) или [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/), чтобы создавать секретные ссылки, не покидая текущую вкладку. Расширение работает через наш публичный API, поэтому требуется тариф **[Top Secret](/pricing)** с ключом API."
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "Webbläsartillägg",
 	"browser_extension_tooltip": "Dela en hemlighet direkt från din webbläsare. Kräver en API-nyckel.",
 	"browser_extension_faq_heading": "Finns det ett webbläsartillägg?",
-	"browser_extension_faq_body": "Ja! Installera [scrt.link-webbläsartillägget](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) för Chrome för att skapa hemliga länkar utan att lämna din aktuella flik. Tillägget kommunicerar med vårt publika API, så en **[Top Secret](/pricing)**-plan med en API-nyckel krävs."
+	"browser_extension_faq_body": "Ja! Installera scrt.link-webbläsartillägget för [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) eller [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) för att skapa hemliga länkar utan att lämna din aktuella flik. Tillägget kommunicerar med vårt publika API, så en **[Top Secret](/pricing)**-plan med en API-nyckel krävs."
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -997,5 +997,5 @@
 	"browser_extension_label": "浏览器扩展",
 	"browser_extension_tooltip": "直接从浏览器分享秘密。需要 API 密钥。",
 	"browser_extension_faq_heading": "有浏览器扩展吗？",
-	"browser_extension_faq_body": "有！为 Chrome 安装 [scrt.link 浏览器扩展](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh)，即可在不离开当前标签页的情况下创建秘密链接。该扩展通过我们的公共 API 通信，因此需要带有 API 密钥的 **[Top Secret](/pricing)** 套餐。"
+	"browser_extension_faq_body": "有！为 [Chrome](https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh) 或 [Firefox](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) 安装 scrt.link 浏览器扩展，即可在不离开当前标签页的情况下创建秘密链接。该扩展通过我们的公共 API 通信，因此需要带有 API 密钥的 **[Top Secret](/pricing)** 套餐。"
 }

--- a/src/lib/data/app.ts
+++ b/src/lib/data/app.ts
@@ -22,8 +22,10 @@ export const emailSupport = 'support@scrt.link';
 export const emailNoReply = 'no-reply@scrt.link';
 export const uptimerobotUrl = 'https://stats.uptimerobot.com/v5yqDuEr5z';
 export const githubUrl = 'https://github.com/stophecom/scrt-link-v2';
-export const browserExtensionUrl =
+export const chromeExtensionUrl =
 	'https://chromewebstore.google.com/detail/scrtlink-%E2%80%94-share-a-secret/ljcmmhacpghmooiojfdiekokhefopmmh';
+export const firefoxExtensionUrl =
+	'https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/';
 export const blueskyUrl = 'https://bsky.app/profile/scrt.link';
 export const linkedinUrl = 'https://www.linkedin.com/company/santihans';
 

--- a/src/lib/data/menu.ts
+++ b/src/lib/data/menu.ts
@@ -9,7 +9,7 @@ import {
 
 import { m } from '$lib/paraglide/messages.js';
 
-import { browserExtensionUrl, githubUrl } from './app';
+import { chromeExtensionUrl, firefoxExtensionUrl, githubUrl } from './app';
 
 export const secretMenu = () => [
 	{
@@ -63,9 +63,14 @@ export const productMenu = () => [
 		label: 'CLI'
 	},
 	{
-		href: browserExtensionUrl,
+		href: chromeExtensionUrl,
 		externalLink: true,
 		label: 'Chrome Extension'
+	},
+	{
+		href: firefoxExtensionUrl,
+		externalLink: true,
+		label: 'Firefox Extension'
 	},
 	{
 		href: 'https://deepwiki.com/stophecom/scrt-link-v2',


### PR DESCRIPTION
## Summary

Promotes the new [Firefox Add-ons listing](https://addons.mozilla.org/en-US/firefox/addon/scrt-link-share-a-secret/) alongside the existing Chrome Web Store extension, mirroring the earlier Chrome promotion (#316).

## Changes

- **`app.ts`** — add `firefoxExtensionUrl`; rename `browserExtensionUrl` → `chromeExtensionUrl` for clarity.
- **`menu.ts`** — add a **"Firefox Extension"** link to the footer product menu, next to the Chrome one.
- **`en.json`** — FAQ body now links both **Chrome** and **Firefox**; re-translated across all 13 other locales (the old copy only mentioned Chrome).

The generic "Browser Extension" feature label on the Top Secret plan card and comparison tables is left untouched — it already covers both browsers.

## Verification

Ran the dev server and confirmed:
- Footer renders the Firefox link with the correct `href` and `target="_blank"`.
- `/faq` renders "Chrome or Firefox" with both links present.
- `pnpm lint` shows no new issues (only pre-existing generated-file warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)