### PR TITLE
fix(pricing): remove browser extension from Secret Service plan

### DIFF
--- a/src/routes/(app)/(default)/pricing/comparison-table.svelte
+++ b/src/routes/(app)/(default)/pricing/comparison-table.svelte
@@ -53,7 +53,7 @@
 		{ label: m.kind_sharp_owl_record(), values: [true, true] },
 		{ label: m.warm_dark_owl_gaze(), values: ['7 days', '30 days'] },
 		{ label: m.few_away_tadpole_hope(), values: [true, true] },
-		{ label: m.browser_extension_label(), values: [true, true] },
+		{ label: m.browser_extension_label(), values: [false, true] },
 		{ label: m.bold_slim_ram_roam(), values: [true, true] },
 		{ label: m.wild_inner_fox_honor(), values: [true, true] },
 		{ label: m.bold_stat_log_feat(), values: [false, true] },


### PR DESCRIPTION
## Summary

Browser Extension was incorrectly marked as available on the **Secret Service** business plan in the pricing comparison table. It's only offered on **Top Secret Service**.

Changed the Business `Browser Extension` row from `[true, true]` to `[false, true]`.

## Verification

Loaded `/pricing`, toggled to Business view, and confirmed the Browser Extension row renders:
- **Secret Service**: ✗ (unavailable)
- **Top Secret Service**: ✓ (available)

Personal table and `plans.ts` feature bullets were already consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)