### PR TITLE
fix(white-label): apply custom request texts on recipient page

### DIFF
--- a/src/lib/server/whiteLabelSite.ts
+++ b/src/lib/server/whiteLabelSite.ts
@@ -2,10 +2,30 @@ import { eq } from 'drizzle-orm';
 
 import { isOriginalHostname } from '$lib/app-routing';
 import { TierOptions } from '$lib/data/enums';
+import { getLocale } from '$lib/paraglide/runtime';
+import type { LocalizedWhiteLabelMessage } from '$lib/types';
 
 import { db } from './db';
 import { organization, user, whiteLabelSite } from './db/schema';
 import { getMembersByOrganizationId } from './organization';
+
+// Resolves the editable title/lead for a white-label page section (the secret
+// request `/r` flow or the secret reception `/s` reveal flow) from the site's
+// stored messages, in the active locale. Returns empty strings when unset so
+// callers can fall back to the default i18n copy.
+export const getWhiteLabelPageTexts = (
+	site: { messages?: unknown } | null | undefined,
+	section: 'request' | 'reception'
+): { title: string; lead: string } => {
+	const locale = getLocale();
+	const messages = site?.messages as LocalizedWhiteLabelMessage | undefined;
+	const sectionMessages = messages?.[locale]?.[section];
+
+	return {
+		title: sectionMessages?.title || '',
+		lead: sectionMessages?.lead || ''
+	};
+};
 
 export const getWhiteLabelSiteByHost = async (host: string) => {
 	const [whiteLabelResult] = await db

--- a/src/routes/white-label/[domain]/(default)/r/+page.server.ts
+++ b/src/routes/white-label/[domain]/(default)/r/+page.server.ts
@@ -1,5 +1,4 @@
-import { getLocale } from '$lib/paraglide/runtime';
-import type { LocalizedWhiteLabelMessage } from '$lib/types';
+import { getWhiteLabelPageTexts } from '$lib/server/whiteLabelSite';
 
 import type { PageServerLoad } from './$types';
 
@@ -7,11 +6,5 @@ import type { PageServerLoad } from './$types';
 // /r/[requestIdHash]; this bare route exists so the white-label editor can preview the
 // request texts, so it intentionally renders regardless of the enableSecretRequests flag.
 export const load: PageServerLoad = async ({ locals }) => {
-	const locale = getLocale();
-	const messages = locals.whiteLabelSite?.messages as LocalizedWhiteLabelMessage | undefined;
-
-	return {
-		title: messages?.[locale]?.request?.title || '',
-		lead: messages?.[locale]?.request?.lead || ''
-	};
+	return getWhiteLabelPageTexts(locals.whiteLabelSite, 'request');
 };

--- a/src/routes/white-label/[domain]/(default)/r/[requestIdHash]/+page.server.ts
+++ b/src/routes/white-label/[domain]/(default)/r/[requestIdHash]/+page.server.ts
@@ -3,6 +3,7 @@ import { error } from '@sveltejs/kit';
 import { postSecretResponse } from '$lib/server/form/actions';
 import { secretResponseFormValidator } from '$lib/server/form/validators';
 import { loadSecretResponsePageData } from '$lib/server/secret-requests';
+import { getWhiteLabelPageTexts } from '$lib/server/whiteLabelSite';
 
 import type { Actions, PageServerLoad, RequestEvent } from './$types';
 
@@ -16,6 +17,7 @@ export const load: PageServerLoad = async (event) => {
 	assertFeatureEnabled(event);
 	return {
 		form: await secretResponseFormValidator(),
+		...getWhiteLabelPageTexts(event.locals.whiteLabelSite, 'request'),
 		...(await loadSecretResponsePageData(event.params.requestIdHash))
 	};
 };

--- a/src/routes/white-label/[domain]/(default)/r/[requestIdHash]/+page.svelte
+++ b/src/routes/white-label/[domain]/(default)/r/[requestIdHash]/+page.svelte
@@ -9,9 +9,9 @@
 </script>
 
 <WhiteLabelPage
-	metaTitle={m.brave_kind_lamb_give()}
-	title={m.brave_kind_lamb_give()}
-	lead={m.warm_safe_dove_tell()}
+	metaTitle={data.title || m.brave_kind_lamb_give()}
+	title={data.title || m.brave_kind_lamb_give()}
+	lead={data.lead || m.warm_safe_dove_tell()}
 >
 	<SecretResponse {data} bind:successMessage />
 </WhiteLabelPage>

--- a/src/routes/white-label/[domain]/(default)/s/+page.server.ts
+++ b/src/routes/white-label/[domain]/(default)/s/+page.server.ts
@@ -1,8 +1,7 @@
 import { superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
-import { getLocale } from '$lib/paraglide/runtime';
-import type { LocalizedWhiteLabelMessage } from '$lib/types';
+import { getWhiteLabelPageTexts } from '$lib/server/whiteLabelSite';
 import { revealSecretFormSchema } from '$lib/validators/formSchemas';
 
 import { actions } from '../../../../(app)/(default)/s/+page.server';
@@ -11,12 +10,8 @@ import type { PageServerLoad } from './$types';
 export { actions };
 
 export const load: PageServerLoad = async ({ locals }) => {
-	const locale = getLocale();
-	const messages = locals.whiteLabelSite?.messages as LocalizedWhiteLabelMessage | undefined;
-
 	return {
 		form: await superValidate(zod4(revealSecretFormSchema())),
-		title: messages?.[locale]?.reception?.title || '',
-		lead: messages?.[locale]?.reception?.lead || ''
+		...getWhiteLabelPageTexts(locals.whiteLabelSite, 'reception')
 	};
 };


### PR DESCRIPTION
## Problem

The secret-request **recipient** page (`/r/[requestIdHash]`) hardcoded the default i18n title/lead and never read the white-label site's editable texts. So an admin's saved custom copy for the request page was silently ignored on the page recipients actually see — only the editor's **preview** page (bare `/r`) honored it.

## Fix

The "resolve `title`/`lead` from the site's stored `messages` in the active locale, with i18n fallback" logic was duplicated across the `/r` preview and the `/s` reveal page, and simply missing from the recipient page. Extracted it into one helper — `getWhiteLabelPageTexts(site, 'request' | 'reception')` in `src/lib/server/whiteLabelSite.ts` — and routed all three loads through it:

- `/r/[requestIdHash]` recipient page — now returns and applies the custom request texts (**the bug fix**).
- `/r` preview and `/s` reveal — refactored onto the shared helper so the preview and the real page can no longer drift.

Merging the two `/r` routes into one wasn't viable: the recipient page needs the `requestIdHash` param and real request data, while the preview is a bare placeholder rendered by the editor. Sharing the text-resolution helper removes the actual duplication instead.

## Verification

- `pnpm check` clean for the touched files (pre-existing errors elsewhere are unrelated).
- Not driven in-browser: exercising the recipient page needs a fixture stack (custom-domain host routing, a `white_label_site` row with `messages.request.title/lead`, and a live secret request). The change mirrors the already-working `/s` reveal and `/r` preview pattern exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)