### PR TITLE
fix(stripe): re-derive tier from live subscriptions + webhook event log

### DIFF
--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -288,6 +288,33 @@ export const apiKey = pgTable('api_key', {
 	userId: uuid('user_id').references(() => user.id, { onDelete: 'cascade' })
 });
 
+export const stripeWebhookEventStatus = pgEnum('stripe_webhook_event_status', [
+	'received',
+	'processed',
+	'failed'
+]);
+
+// Durable audit trail + idempotency guard for incoming Stripe webhooks.
+// eventId is Stripe's `evt_...` id and doubles as the idempotency key.
+export const stripeWebhookEvent = pgTable(
+	'stripe_webhook_event',
+	{
+		id: uuid('id').defaultRandom().primaryKey(),
+		eventId: text('event_id').notNull().unique(),
+		type: text('type').notNull(),
+		customerId: text('customer_id'),
+		payload: jsonb('payload').notNull(),
+		status: stripeWebhookEventStatus('status').notNull().default('received'),
+		error: text('error'),
+		createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+		processedAt: timestamp('processed_at', { withTimezone: true, mode: 'date' })
+	},
+	(table) => [
+		index('stripe_webhook_event_customer_id_idx').on(table.customerId),
+		index('stripe_webhook_event_type_idx').on(table.type)
+	]
+);
+
 export const scope = pgEnum('scope', ['global', 'user', 'whiteLabel']);
 export const stats = pgTable('stats', {
 	id: serial('id').primaryKey(),
@@ -319,3 +346,4 @@ export type Secret = typeof secret.$inferSelect;
 export type APIKey = typeof apiKey.$inferSelect;
 export type SecretRequest = typeof secretRequest.$inferSelect;
 export type Stats = typeof stats.$inferSelect;
+export type StripeWebhookEvent = typeof stripeWebhookEvent.$inferSelect;

--- a/src/lib/server/stripe.ts
+++ b/src/lib/server/stripe.ts
@@ -93,6 +93,22 @@ export const getActiveSubscription = async (stripeCustomerId: string) => {
 	return activeSubscriptions || null;
 };
 
+/** Maps a subscription to a TierOptions by finding the first item whose product
+ *  name matches a known tier (skips companion "...Base fee" products).
+ *  Falls back to CONFIDENTIAL when nothing maps. */
+export const deriveTierFromSubscription = async (
+	subscription: Stripe.Subscription
+): Promise<TierOptions> => {
+	for (const item of subscription.items.data) {
+		const productId = item.plan.product;
+		if (typeof productId !== 'string') continue;
+		const product = await stripeInstance.products.retrieve(productId);
+		const tier = getEnumFromString(TierOptions, product.name);
+		if (tier) return tier;
+	}
+	return TierOptions.CONFIDENTIAL;
+};
+
 /** Retrieves a completed checkout session with its subscription expanded. */
 export const getCheckoutSession = async (sessionId: string) =>
 	(await stripeInstance.checkout.sessions.retrieve(sessionId, {

--- a/src/routes/api/v1/webhooks/+server.ts
+++ b/src/routes/api/v1/webhooks/+server.ts
@@ -5,13 +5,137 @@ import Stripe from 'stripe';
 import { STRIPE_WEBHOOK_SECRET } from '$env/static/private';
 import { TierOptions } from '$lib/data/enums';
 import { db } from '$lib/server/db';
-import { organization, user, whiteLabelSite } from '$lib/server/db/schema';
+import { organization, stripeWebhookEvent, user, whiteLabelSite } from '$lib/server/db/schema';
 import { removeContactFromAudience } from '$lib/server/resend';
-import stripeInstance from '$lib/server/stripe';
+import stripeInstance, {
+	deriveTierFromSubscription,
+	getActiveSubscription
+} from '$lib/server/stripe';
 import { sendSubscriptionTrialStartEmail } from '$lib/server/transactional-email';
-import { getEnumFromString } from '$lib/typescript-helpers';
 
 const webhookSecret: string = STRIPE_WEBHOOK_SECRET!;
+
+/** Best-effort extraction of the Stripe customer id for logging/filtering. */
+const getCustomerId = (event: Stripe.Event): string | null => {
+	const object = event.data.object as { customer?: string | Stripe.Customer | null };
+	const customer = object?.customer;
+	if (typeof customer === 'string') return customer;
+	if (customer && typeof customer === 'object') return customer.id;
+	return null;
+};
+
+/**
+ * Resolves the tier a customer should currently have, based on their *live*
+ * set of subscriptions in Stripe — NOT the status carried by a single event.
+ * This makes handling order-independent and idempotent: a `canceled`/`deleted`
+ * event for one subscription can no longer downgrade a customer who still holds
+ * another active subscription.
+ */
+const resolveTargetTier = async (customerId: string): Promise<TierOptions> => {
+	const activeSubscription = await getActiveSubscription(customerId);
+	return activeSubscription
+		? await deriveTierFromSubscription(activeSubscription)
+		: TierOptions.CONFIDENTIAL;
+};
+
+const handleOrgSubscription = async (customerId: string): Promise<void> => {
+	const targetTier = await resolveTargetTier(customerId);
+
+	const [orgResult] = await db
+		.update(organization)
+		.set({ subscriptionTier: targetTier })
+		.where(eq(organization.stripeCustomerId, customerId))
+		.returning();
+
+	if (!orgResult) {
+		console.warn(`[webhook] no org found for customerId ${customerId}`);
+		return;
+	}
+
+	// No active subscription remains → unpublish the white-label site.
+	if (targetTier === TierOptions.CONFIDENTIAL) {
+		await db
+			.update(whiteLabelSite)
+			.set({ published: false })
+			.where(eq(whiteLabelSite.organizationId, orgResult.id));
+	}
+
+	console.log('✅ Org tier resolved:', customerId, targetTier);
+};
+
+const handleUserSubscription = async (event: Stripe.Event, customerId: string): Promise<void> => {
+	const activeSubscription = await getActiveSubscription(customerId);
+	const targetTier = activeSubscription
+		? await deriveTierFromSubscription(activeSubscription)
+		: TierOptions.CONFIDENTIAL;
+
+	const [userResult] = await db
+		.update(user)
+		.set({ subscriptionTier: targetTier })
+		.where(eq(user.stripeCustomerId, customerId))
+		.returning();
+
+	if (!userResult) {
+		console.warn(`[webhook] no user found for customerId ${customerId}`);
+		return;
+	}
+
+	if (targetTier === TierOptions.CONFIDENTIAL) {
+		// No active subscription remains → unpublish the white-label site.
+		await db
+			.update(whiteLabelSite)
+			.set({ published: false })
+			.where(eq(whiteLabelSite.userId, userResult.id));
+		console.log('✅ User downgraded to Confidential:', customerId);
+		return;
+	}
+
+	// Customer has an active/trialing subscription.
+	// Send the trial email only on the initial `created` event to avoid duplicates.
+	if (activeSubscription?.status === 'trialing' && event.type === 'customer.subscription.created') {
+		await sendSubscriptionTrialStartEmail(userResult.email, targetTier, userResult.name || '');
+	}
+
+	try {
+		const result = await removeContactFromAudience({ email: userResult.email });
+		if (result.error) throw Error(result.error.message);
+	} catch (error) {
+		console.error(error);
+	}
+
+	console.log('✅ User tier resolved:', customerId, targetTier);
+};
+
+/** Dispatches a verified Stripe event. Throws on failure so the caller can
+ *  mark the event failed and return a non-2xx, letting Stripe retry. */
+const processEvent = async (event: Stripe.Event): Promise<void> => {
+	switch (event.type) {
+		case 'customer.subscription.created':
+		case 'customer.subscription.deleted':
+		case 'customer.subscription.updated': {
+			const subscription = event.data.object as Stripe.Subscription;
+			const customerId = subscription.customer as string;
+
+			// Org billing takes priority over personal billing for a given customer.
+			const [orgResult] = await db
+				.select()
+				.from(organization)
+				.where(eq(organization.stripeCustomerId, customerId))
+				.limit(1);
+
+			if (orgResult) {
+				await handleOrgSubscription(customerId);
+			} else {
+				await handleUserSubscription(event, customerId);
+			}
+			break;
+		}
+
+		default: {
+			console.warn(`Unhandled event type: ${event.type}`);
+		}
+	}
+};
 
 export const POST: RequestHandler = async ({ request }) => {
 	const rawBody = await request.text();
@@ -27,157 +151,55 @@ export const POST: RequestHandler = async ({ request }) => {
 		return new Response(errorMessage, { status: 400 });
 	}
 
-	// Successfully constructed event.
-	console.log('✅ Success:', event.id);
+	// Idempotency + audit trail: record the event keyed on Stripe's event id.
+	// `onConflictDoNothing` means a duplicate delivery inserts no new row.
+	const [inserted] = await db
+		.insert(stripeWebhookEvent)
+		.values({
+			eventId: event.id,
+			type: event.type,
+			customerId: getCustomerId(event),
+			payload: event as unknown as Record<string, unknown>,
+			status: 'received'
+		})
+		.onConflictDoNothing({ target: stripeWebhookEvent.eventId })
+		.returning();
 
-	switch (event.type) {
-		case 'customer.subscription.created':
-		case 'customer.subscription.deleted':
-		case 'customer.subscription.updated': {
-			const subscription = event.data.object as Stripe.Subscription;
+	if (!inserted) {
+		// We've seen this event id before. Only skip if it was fully processed;
+		// a previously-failed event is allowed to reprocess on Stripe's retry.
+		const [existing] = await db
+			.select({ status: stripeWebhookEvent.status })
+			.from(stripeWebhookEvent)
+			.where(eq(stripeWebhookEvent.eventId, event.id))
+			.limit(1);
 
-			// If payment successful the status changes to active:
-			// https://stripe.com/docs/api/subscriptions/object#subscription_object-status
-			// Possible values are incomplete, incomplete_expired, trialing, active, past_due, canceled, unpaid, or paused.
-			const customerId = subscription.customer as string;
-
-			// Check if this customer belongs to an org (org billing takes priority)
-			const [orgResult] = await db
-				.select()
-				.from(organization)
-				.where(eq(organization.stripeCustomerId, customerId))
-				.limit(1);
-
-			if (orgResult) {
-				// Org subscription event
-				if (['trialing', 'active'].includes(subscription.status)) {
-					try {
-						let purchasedTier = TierOptions.CONFIDENTIAL;
-
-						// With base-fee + seat line items, find the item whose product name
-						// maps to a known TierOptions (skip companion "...Base fee" products)
-						for (const item of subscription.items.data) {
-							const productId = item.plan.product;
-							console.log('Purchased product: ', productId);
-							console.log('Customer: ', customerId);
-							if (typeof productId !== 'string') continue;
-							const plan = await stripeInstance.products.retrieve(productId);
-							const mappedTierOption = getEnumFromString(TierOptions, plan.name);
-							if (mappedTierOption) {
-								purchasedTier = mappedTierOption;
-								break;
-							}
-						}
-
-						await db
-							.update(organization)
-							.set({ subscriptionTier: purchasedTier })
-							.where(eq(organization.stripeCustomerId, customerId));
-
-						console.log('✅ Org subscription active:', event.type, purchasedTier);
-					} catch (e) {
-						console.error(e);
-					}
-				} else if (['canceled', 'unpaid'].includes(subscription.status)) {
-					try {
-						const [orgResult] = await db
-							.update(organization)
-							.set({ subscriptionTier: TierOptions.CONFIDENTIAL })
-							.where(eq(organization.stripeCustomerId, customerId))
-							.returning();
-
-						if (!orgResult) {
-							console.warn(`[webhooks] No org found for customerId ${customerId} on cancellation`);
-						} else {
-							await db
-								.update(whiteLabelSite)
-								.set({ published: false })
-								.where(eq(whiteLabelSite.organizationId, orgResult.id));
-						}
-					} catch (error) {
-						console.error('[webhooks] Failed to process org cancellation:', error);
-					}
-				}
-			} else if (['trialing', 'active'].includes(subscription.status)) {
-				// Personal subscription event
-				try {
-					const product = subscription.items.data[0].plan.product;
-					console.log('Purchased product: ', product);
-					console.log('Customer: ', customerId);
-
-					let purchasedTier = TierOptions.CONFIDENTIAL;
-
-					if (typeof product === 'string') {
-						const plan = await stripeInstance.products.retrieve(product);
-
-						console.log('Plan Name', plan.name);
-						const mappedTierOption = getEnumFromString(TierOptions, plan.name);
-						if (mappedTierOption) {
-							console.log('Purchased tier option: ', mappedTierOption);
-							purchasedTier = mappedTierOption;
-						}
-					}
-
-					const [userResult] = await db
-						.update(user)
-						.set({ subscriptionTier: purchasedTier })
-						.where(eq(user.stripeCustomerId, customerId))
-						.returning();
-
-					if (!userResult) {
-						console.warn(`[webhook] no user found for customerId ${customerId}`);
-						break;
-					}
-
-					if (subscription.status === 'trialing') {
-						await sendSubscriptionTrialStartEmail(
-							userResult.email,
-							purchasedTier,
-							userResult.name || ''
-						);
-					}
-
-					try {
-						const result = await removeContactFromAudience({ email: userResult.email });
-						if (result.error) throw Error(result.error.message);
-					} catch (error) {
-						console.error(error);
-					}
-
-					console.log('✅ Subscription active:', event.type);
-				} catch (e) {
-					console.error(e);
-				}
-			} else if (['canceled', 'unpaid'].includes(subscription.status)) {
-				const [userResult] = await db
-					.update(user)
-					.set({ subscriptionTier: TierOptions.CONFIDENTIAL })
-					.where(eq(user.stripeCustomerId, customerId))
-					.returning();
-
-				if (!userResult) {
-					console.warn(`[webhook] no user found for customerId ${customerId} on cancellation`);
-					break;
-				}
-
-				try {
-					await db
-						.update(whiteLabelSite)
-						.set({ published: false })
-						.where(eq(whiteLabelSite.userId, userResult.id));
-				} catch (error) {
-					console.error(error);
-				}
-			}
-
-			break;
+		if (existing?.status === 'processed') {
+			console.log('[webhook] duplicate already processed, skipping:', event.id);
+			return json({ success: true, duplicate: true });
 		}
-
-		default: {
-			console.warn(`Unhandled event type: ${event.type}`);
-		}
+		console.log('[webhook] reprocessing previously failed event:', event.id);
 	}
 
-	// Return a response to acknowledge receipt of the event.
-	return json({ success: true });
+	try {
+		await processEvent(event);
+
+		await db
+			.update(stripeWebhookEvent)
+			.set({ status: 'processed', error: null, processedAt: new Date() })
+			.where(eq(stripeWebhookEvent.eventId, event.id));
+
+		return json({ success: true });
+	} catch (e) {
+		const errorMessage = e instanceof Error ? e.message : 'Unexpected error';
+		console.error('[webhook] processing failed:', event.id, event.type, errorMessage);
+
+		await db
+			.update(stripeWebhookEvent)
+			.set({ status: 'failed', error: errorMessage })
+			.where(eq(stripeWebhookEvent.eventId, event.id));
+
+		// Return 5xx so Stripe retries (with backoff, for ~3 days).
+		return new Response(errorMessage, { status: 500 });
+	}
 };


### PR DESCRIPTION
## Problem

A customer whose subscription showed **Active** in the Stripe dashboard was treated as un-subscribed by the app. The cause: a second, **Canceled** subscription on the same customer. Its `customer.subscription.deleted`/`canceled` webhook unconditionally downgraded the customer to `Confidential` — the handler keyed only on `stripeCustomerId` and never checked whether *another* active subscription still existed.

Because Stripe delivers webhook events **at-least-once and out of order**, this also meant a stale/duplicate cancel event could stomp an active tier.

## Fix

Every `customer.subscription.*` event now re-derives the target tier from the customer's **live** set of subscriptions via `getActiveSubscription()`, rather than trusting the status carried by a single event:

- Active/trialing subscription remains → tier set from that subscription.
- No active subscription remains → downgrade to `Confidential` + unpublish white-label site.

This makes handling **order-independent** and **idempotent**. A cancel can only downgrade when nothing active is left.

## Webhook event log + idempotency

New `stripe_webhook_event` table (unique `event_id`, `type`, indexed `customer_id`, `payload` jsonb, `status`, `error`, timestamps):

- **Audit trail** — durable record of every event and its outcome, queryable per customer for debugging (Vercel function logs are ephemeral).
- **Idempotency** — insert keyed on `event_id`; an already-`processed` duplicate is skipped, a previously-`failed` event may reprocess.
- **Retries** — genuine processing failures now mark the row `failed` and return **500**, so Stripe retries with backoff (~3 days) instead of the handler always returning `200`.

Also tightened: the trial-start email now fires only on the initial `customer.subscription.created` event, preventing duplicate sends.

## Migration

Additive only — new enum + table. Apply with:

\`\`\`bash
pnpm run db:push
\`\`\`

## Testing notes

Not yet exercised against a live Stripe stream. Recommend verifying locally with:

\`\`\`bash
stripe listen --forward-to localhost:5173/api/v1/webhooks
stripe trigger customer.subscription.deleted
\`\`\`

then inspecting `stripe_webhook_event` rows and the resulting tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)