### PR TITLE
fix(emails): drop svelte-email-tailwind for vanilla inline-CSS templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
 		"prettier-plugin-tailwindcss": "^0.7.2",
 		"svelte": "^5.55.7",
 		"svelte-check": "^4.1.1",
-		"svelte-email-tailwind": "^4.0.0",
 		"svelte-sonner": "^0.3.28",
 		"sveltekit-rate-limiter": "^0.7.0",
 		"sveltekit-superforms": "^2.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
       svelte-check:
         specifier: ^4.1.1
         version: 4.3.6(picomatch@4.0.4)(svelte@5.55.7(@typescript-eslint/types@8.54.0))(typescript@5.9.3)
-      svelte-email-tailwind:
-        specifier: ^4.0.0
-        version: 4.0.0(@typescript-eslint/types@8.54.0)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       svelte-sonner:
         specifier: ^0.3.28
         version: 0.3.28(svelte@5.55.7(@typescript-eslint/types@8.54.0))
@@ -305,10 +302,6 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@ark/schema@0.56.0':
     resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
@@ -721,10 +714,6 @@ packages:
   '@internationalized/date@3.12.0':
     resolution: {integrity: sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -766,21 +755,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
-
-  '@one-ini/wasm@0.1.1':
-    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
-
   '@oslojs/asn1@1.0.0':
     resolution: {integrity: sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA==}
 
@@ -801,10 +775,6 @@ packages:
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -834,10 +804,6 @@ packages:
 
   '@poppinss/macroable@1.1.0':
     resolution: {integrity: sha512-y/YKzZDuG8XrpXpM7Z1RdQpiIc0MAKyva24Ux1PB4aI7RiSI/79K8JVDcdyubriTm7vJ1LhFs8CrZpmPnx/8Pw==}
-
-  '@react-email/render@0.0.9':
-    resolution: {integrity: sha512-nrim7wiACnaXsGtL7GF6jp3Qmml8J6vAjAH88jkC8lIbfNZaCyuPQHANjyYIXlvQeAbsWADQJFZgOHUqFqjh/A==}
-    engines: {node: '>=18.0.0'}
 
   '@react-email/render@1.1.2':
     resolution: {integrity: sha512-RnRehYN3v9gVlNMehHPHhyp2RQo7+pSkHDtXPvg3s0GbzM9SQMW4Qrf8GRNvtpLC4gsI+Wt0VatNRUFqjvevbw==}
@@ -1262,13 +1228,6 @@ packages:
       svelte: ^5.0.0
       vite: ^6.3.0 || ^7.0.0
 
-  '@sveltejs/vite-plugin-svelte@6.1.0':
-    resolution: {integrity: sha512-+U6lz1wvGEG/BvQyL4z/flyNdQ9xDNv5vrh+vWBWTHaebqT0c9RNggpZTo/XSPoHsSCWBlYaTlRX8pZ9GATXCw==}
-    engines: {node: ^20.19 || ^22.12 || >=24}
-    peerDependencies:
-      svelte: ^5.0.0
-      vite: ^6.3.0 || ^7.0.0
-
   '@sveltejs/vite-plugin-svelte@6.2.4':
     resolution: {integrity: sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==}
     engines: {node: ^20.19 || ^22.12 || >=24}
@@ -1637,10 +1596,6 @@ packages:
   '@wxt-dev/storage@1.2.8':
     resolution: {integrity: sha512-GWCFKgF5+d7eslOxUDFC70ypA9njupmJb1nQM8uZoX0J3sWT2BO5xJLzb1sYahWAfID9p2BMtnUBN1lkWxPsbQ==}
 
-  abbrev@2.0.0:
-    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -1710,15 +1665,8 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   arctic@2.3.4:
     resolution: {integrity: sha512-+p30BOWsctZp+CVYCt7oAean/hWGW42sH5LAcRQX56ttEkFJWbzXBhmSpibbzwSJkRrotmsA+oAoJoVsU0f5xA==}
-
-  arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1728,10 +1676,6 @@ packages:
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
-    engines: {node: '>= 0.4'}
-
-  aria-query@5.3.2:
-    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
   arkregex@0.0.5:
@@ -1796,10 +1740,6 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -1832,10 +1772,6 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
-
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1877,10 +1813,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
-
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
@@ -1906,10 +1838,6 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1969,10 +1897,6 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
-  commander@10.0.1:
-    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
-    engines: {node: '>=14'}
-
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
@@ -2010,10 +1934,6 @@ packages:
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
-
-  condense-newlines@0.2.1:
-    resolution: {integrity: sha512-P7X+QL9Hb9B/c8HI5BFFKmjgBu2XpQuF98WZ9XkO+dBGgk5XgwiQz7o1SmpglNWId3581UcS0SFAWfoIhMHPfg==}
-    engines: {node: '>=0.10.0'}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2173,9 +2093,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
@@ -2317,16 +2234,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
-
-  editorconfig@1.0.4:
-    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   effect@3.21.0:
     resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
@@ -2336,9 +2245,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -2407,10 +2313,6 @@ packages:
   escape-goat@4.0.0:
     resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
     engines: {node: '>=12'}
-
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2515,10 +2417,6 @@ packages:
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
 
-  extend-shallow@2.0.1:
-    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
-    engines: {node: '>=0.10.0'}
-
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -2532,10 +2430,6 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -2545,9 +2439,6 @@ packages:
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
-
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2568,10 +2459,6 @@ packages:
   filesize@11.0.19:
     resolution: {integrity: sha512-9Q2itINBvCHwFw9v5X7czZm855yAiFIYlnugrh7+8tYO4ITHZMzV91m35q2FngL9hoZwwjSTQACFF/W52OzJZQ==}
     engines: {node: '>= 10.8.0'}
-
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2600,10 +2487,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
 
   form-data-encoder@4.1.0:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
@@ -2675,21 +2558,12 @@ packages:
     resolution: {integrity: sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw==}
     hasBin: true
 
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -2832,13 +2706,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
-  is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
@@ -2852,10 +2719,6 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
-
-  is-extendable@0.1.1:
-    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
-    engines: {node: '>=0.10.0'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2898,10 +2761,6 @@ packages:
     resolution: {integrity: sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
@@ -2935,10 +2794,6 @@ packages:
     resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
     engines: {node: '>=10'}
 
-  is-whitespace@0.3.0:
-    resolution: {integrity: sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==}
-    engines: {node: '>=0.10.0'}
-
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
@@ -2964,13 +2819,6 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
-  jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
-    hasBin: true
-
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -2981,14 +2829,6 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
-
-  js-beautify@1.15.4:
-    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
-    engines: {node: '>=14'}
-    hasBin: true
-
-  js-cookie@3.0.8:
-    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-sha256@0.11.1:
     resolution: {integrity: sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==}
@@ -3047,10 +2887,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  kind-of@3.2.2:
-    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
-    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3249,9 +3085,6 @@ packages:
   lowlight@3.3.0:
     resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
@@ -3332,10 +3165,6 @@ packages:
 
   memoize-weak@1.0.2:
     resolution: {integrity: sha512-gj39xkrjEw7nCn4nJ1M5ms6+MyMlyiGmttzsqAUsAKn6bYKwuTHh/AO3cKPF8IBrTIYTxb0wWXFs3E//Y8VoWQ==}
-
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3421,10 +3250,6 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
-
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -3443,10 +3268,6 @@ packages:
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@9.0.1:
-    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
@@ -3539,11 +3360,6 @@ packages:
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==}
 
-  nopt@7.2.1:
-    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    hasBin: true
-
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -3568,10 +3384,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -3618,9 +3430,6 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
@@ -3649,10 +3458,6 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -3685,10 +3490,6 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
 
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
@@ -3725,38 +3526,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss-css-variables@0.18.0:
-    resolution: {integrity: sha512-lYS802gHbzn1GI+lXvy9MYIYDuGnl1WB4FTKoqMQqJ3Mab09A7a/1wZvGTkCEZJTM8mSbIyb1mJYn8f0aPye0Q==}
-    peerDependencies:
-      postcss: ^8.2.6
-
-  postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.1.0:
-    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
     peerDependencies:
       postcss: '>=8.0.9'
       ts-node: '>=9.0.0'
@@ -3784,12 +3556,6 @@ packages:
       yaml:
         optional: true
 
-  postcss-nested@6.2.0:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
-
   postcss-safe-parser@7.0.1:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
@@ -3806,20 +3572,9 @@ packages:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
-
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
-
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -3915,10 +3670,6 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  pretty@2.0.0:
-    resolution: {integrity: sha512-G9xUchgTEiNpormdYBl+Pha50gOUovT18IvAe7EYMZ1/f9W/WWMPRn+xI68yXNMUk3QXHDwo/1wV/4NejVNe1w==}
-    engines: {node: '>=0.10.0'}
-
   prism-svelte@0.4.7:
     resolution: {integrity: sha512-yABh19CYbM24V7aS7TuPYRNMqthxwbvx6FF/Rw920YbyBWO3tnyPIqRMgHuSVsLmuHkkBS1Akyof463FVdkeDQ==}
 
@@ -3973,9 +3724,6 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -4001,15 +3749,8 @@ packages:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
 
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
-
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -4050,10 +3791,6 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resend@2.0.0:
-    resolution: {integrity: sha512-jAh0DN84ZjjmzGM2vMjJ1hphPBg1mG98dzopF7kJzmin62v8ESg4og2iCKWdkAboGOT2SeO5exbr/8Xh8gLddw==}
-    engines: {node: '>=18'}
-
   resend@4.8.0:
     resolution: {integrity: sha512-R8eBOFQDO6dzRTDmaMEdpqrkmgSjPpVXt4nGfWsZdYOet0kqra0xgbvTES6HmCriZEXbmGk3e0DiGIaLFTFSHA==}
     engines: {node: '>=18'}
@@ -4078,10 +3815,6 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
@@ -4098,9 +3831,6 @@ packages:
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
-
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   runed@0.23.4:
     resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
@@ -4269,10 +3999,6 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -4349,9 +4075,6 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
-  svelte-email-tailwind@4.0.0:
-    resolution: {integrity: sha512-HxJ6ZmSP+DJnq6aj6hsBQ+mqgu94rem6hBkCA5VRMI1HDnZ6jALoqa4iF4+Y4yEsmXuJtcMFarT1S8BnRZyA7g==}
-
   svelte-eslint-parser@1.4.1:
     resolution: {integrity: sha512-1eqkfQ93goAhjAXxZiu1SaKI9+0/sxp4JIWQwUpsz7ybehRE5L8dNuz7Iry7K22R47p5/+s9EM+38nHV2OlgXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0, pnpm: 10.24.0}
@@ -4370,12 +4093,6 @@ packages:
     resolution: {integrity: sha512-Q4lshp0HO2rSM2IKgs/pJTeNTaCuONv8Kdmdr1OaSVeIH5gdJjjYnGHwy2cYoddzhdXAD9F8cwNJDIxGKqDsxg==}
     peerDependencies:
       svelte: ^5.0.0
-
-  svelte-persisted-store@0.12.0:
-    resolution: {integrity: sha512-BdBQr2SGSJ+rDWH8/aEV5GthBJDapVP0GP3fuUCA7TjYG5ctcB+O9Mj9ZC0+Jo1oJMfZUd1y9H68NFRR5MyIJA==}
-    engines: {node: '>=0.14'}
-    peerDependencies:
-      svelte: ^3.48.0 || ^4 || ^5
 
   svelte-sonner@0.3.28:
     resolution: {integrity: sha512-K3AmlySeFifF/cKgsYNv5uXqMVNln0NBAacOYgmkQStLa/UoU0LhfAACU6Gr+YYC8bOCHdVmFNoKuDbMEsppJg==}
@@ -4398,10 +4115,6 @@ packages:
     resolution: {integrity: sha512-762k01kIU+IyXfe5f2MEYQ1yIfJZfueAEmJNbO36cxJG56/vciHiWacPQLnSECK/4cvlH/Ll1Mv6B45InMJ1zg==}
     peerDependencies:
       svelte: '>=3.47.x'
-
-  svelte@5.36.8:
-    resolution: {integrity: sha512-8JbZWQu96hMjH/oYQPxXW6taeC6Awl6muGHeZzJTxQx7NGRQ/J9wN1hkzRKLOlSDlbS2igiFg7p5xyTp5uXG3A==}
-    engines: {node: '>=18'}
 
   svelte@5.55.7:
     resolution: {integrity: sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==}
@@ -4437,11 +4150,6 @@ packages:
     engines: {node: '>=16.x', pnpm: '>=7.x'}
     peerDependencies:
       tailwindcss: '*'
-
-  tailwindcss@3.3.2:
-    resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
 
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
@@ -4505,10 +4213,6 @@ packages:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
 
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
@@ -4566,10 +4270,6 @@ packages:
         optional: true
       typescript:
         optional: true
-
-  tw-to-css@0.0.12:
-    resolution: {integrity: sha512-rQAsQvOtV1lBkyCw+iypMygNHrShYAItES5r8fMsrhhaj5qrV2LkZyXc8ccEH+u5bFjHjQ9iuxe90I7Kykf6pw==}
-    engines: {node: '>=16.0.0'}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4894,10 +4594,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -5006,11 +4702,6 @@ snapshots:
       rollup: 4.60.1
 
   '@alloc/quick-lru@5.2.0': {}
-
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
 
   '@ark/schema@0.56.0':
     dependencies:
@@ -5478,15 +5169,6 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.20
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.2
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
@@ -5543,20 +5225,6 @@ snapshots:
       - encoding
       - supports-color
 
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
-
-  '@one-ini/wasm@0.1.1': {}
-
   '@oslojs/asn1@1.0.0':
     dependencies:
       '@oslojs/binary': 1.0.0
@@ -5577,9 +5245,6 @@ snapshots:
       '@oslojs/encoding': 0.4.1
 
   '@petamoriken/float16@3.9.3':
-    optional: true
-
-  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@playwright/test@1.60.0':
@@ -5611,13 +5276,6 @@ snapshots:
 
   '@poppinss/macroable@1.1.0':
     optional: true
-
-  '@react-email/render@0.0.9':
-    dependencies:
-      html-to-text: 9.0.5
-      pretty: 2.0.0
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
 
   '@react-email/render@1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -5925,32 +5583,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.36.8(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.36.8(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.1.0(svelte@5.36.8(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
-      obug: 2.1.1
-      svelte: 5.36.8(@typescript-eslint/types@8.54.0)
-      vite: 7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
-
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.55.7(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.7(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       obug: 2.1.1
       svelte: 5.55.7(@typescript-eslint/types@8.54.0)
       vite: 7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
-
-  '@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.36.8(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.36.8(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)))(svelte@5.36.8(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
-      debug: 4.4.3
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.21
-      svelte: 5.36.8(@typescript-eslint/types@8.54.0)
-      vite: 7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
-    transitivePeerDependencies:
-      - supports-color
 
   '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.7(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
     dependencies:
@@ -6373,8 +6011,6 @@ snapshots:
       async-mutex: 0.5.0
       dequal: 2.0.3
 
-  abbrev@2.0.0: {}
-
   abbrev@3.0.1: {}
 
   acorn-import-attributes@1.9.5(acorn@8.16.0):
@@ -6428,18 +6064,11 @@ snapshots:
 
   any-promise@1.3.0: {}
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.2
-
   arctic@2.3.4:
     dependencies:
       '@oslojs/crypto': 1.0.1
       '@oslojs/encoding': 1.1.0
       '@oslojs/jwt': 0.2.0
-
-  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -6448,8 +6077,6 @@ snapshots:
       dequal: 2.0.3
 
   aria-query@5.3.1: {}
-
-  aria-query@5.3.2: {}
 
   arkregex@0.0.5:
     dependencies:
@@ -6511,8 +6138,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  binary-extensions@2.3.0: {}
-
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -6560,10 +6185,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
-
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -6608,8 +6229,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-css@2.0.1: {}
-
   camelcase@8.0.0: {}
 
   ccount@2.0.1: {}
@@ -6632,18 +6251,6 @@ snapshots:
   character-entities@2.0.2: {}
 
   check-error@2.1.3: {}
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   chokidar@4.0.3:
     dependencies:
@@ -6704,8 +6311,6 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
-  commander@10.0.1: {}
-
   commander@11.1.0: {}
 
   commander@12.1.0: {}
@@ -6736,12 +6341,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
-
-  condense-newlines@0.2.1:
-    dependencies:
-      extend-shallow: 2.0.1
-      is-whitespace: 0.3.0
-      kind-of: 3.2.2
 
   confbox@0.1.8: {}
 
@@ -6861,9 +6460,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  didyoumean@1.2.2: {}
-
-  dlv@1.1.3: {}
+  dlv@1.1.3:
+    optional: true
 
   dom-accessibility-api@0.5.16: {}
 
@@ -6923,18 +6521,9 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  eastasianwidth@0.2.0: {}
-
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-
-  editorconfig@1.0.4:
-    dependencies:
-      '@one-ini/wasm': 0.1.1
-      commander: 10.0.1
-      minimatch: 9.0.1
-      semver: 7.8.4
 
   effect@3.21.0:
     dependencies:
@@ -6945,8 +6534,6 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -7026,8 +6613,6 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-goat@4.0.0: {}
-
-  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -7149,10 +6734,6 @@ snapshots:
 
   exsolve@1.1.0: {}
 
-  extend-shallow@2.0.1:
-    dependencies:
-      is-extendable: 0.1.1
-
   extend@3.0.2: {}
 
   fast-check@3.23.2:
@@ -7164,23 +6745,11 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
 
   fast-redact@3.5.0: {}
-
-  fastq@1.20.1:
-    dependencies:
-      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -7193,10 +6762,6 @@ snapshots:
   file-uri-to-path@1.0.0: {}
 
   filesize@11.0.19: {}
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
 
   find-up@5.0.0:
     dependencies:
@@ -7225,11 +6790,6 @@ snapshots:
   flatted@3.3.3: {}
 
   follow-redirects@1.16.0: {}
-
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
 
   form-data-encoder@4.1.0: {}
 
@@ -7314,24 +6874,11 @@ snapshots:
 
   giget@3.3.0: {}
 
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
-
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.5
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
 
   glob@13.0.6:
     dependencies:
@@ -7459,12 +7006,6 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
-  is-buffer@1.1.6: {}
-
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.3
@@ -7472,8 +7013,6 @@ snapshots:
   is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
-
-  is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -7504,8 +7043,6 @@ snapshots:
 
   is-npm@6.1.0: {}
 
-  is-number@7.0.0: {}
-
   is-path-inside@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -7530,8 +7067,6 @@ snapshots:
 
   is-retry-allowed@2.2.0: {}
 
-  is-whitespace@0.3.0: {}
-
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
@@ -7551,14 +7086,6 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
-  jiti@1.21.7: {}
-
   jiti@2.6.1: {}
 
   joi@17.13.3:
@@ -7571,16 +7098,6 @@ snapshots:
     optional: true
 
   joycon@3.1.1: {}
-
-  js-beautify@1.15.4:
-    dependencies:
-      config-chain: 1.1.13
-      editorconfig: 1.0.4
-      glob: 10.5.0
-      js-cookie: 3.0.8
-      nopt: 7.2.1
-
-  js-cookie@3.0.8: {}
 
   js-sha256@0.11.1: {}
 
@@ -7650,10 +7167,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  kind-of@3.2.2:
-    dependencies:
-      is-buffer: 1.1.6
 
   kleur@3.0.3: {}
 
@@ -7815,8 +7328,6 @@ snapshots:
       devlop: 1.1.0
       highlight.js: 11.11.1
 
-  lru-cache@10.4.3: {}
-
   lru-cache@11.2.7: {}
 
   lz-string@1.5.0: {}
@@ -7970,8 +7481,6 @@ snapshots:
       vfile-message: 2.0.4
 
   memoize-weak@1.0.2: {}
-
-  merge2@1.4.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -8164,11 +7673,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.2
-
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -8184,10 +7688,6 @@ snapshots:
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
-
-  minimatch@9.0.1:
-    dependencies:
-      brace-expansion: 2.0.2
 
   minimatch@9.0.5:
     dependencies:
@@ -8273,10 +7773,6 @@ snapshots:
       uuid: 8.3.2
       which: 2.0.2
 
-  nopt@7.2.1:
-    dependencies:
-      abbrev: 2.0.0
-
   nopt@8.1.0:
     dependencies:
       abbrev: 3.0.1
@@ -8297,8 +7793,6 @@ snapshots:
       tinyexec: 1.2.4
 
   object-assign@4.1.1: {}
-
-  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -8352,8 +7846,6 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  package-json-from-dist@1.0.1: {}
-
   package-json@10.0.1:
     dependencies:
       ky: 1.14.3
@@ -8386,11 +7878,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.2
-
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.7
@@ -8411,8 +7898,6 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
-
-  pify@2.3.0: {}
 
   pino-abstract-transport@2.0.0:
     dependencies:
@@ -8458,38 +7943,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-css-variables@0.18.0(postcss@8.4.31):
-    dependencies:
-      balanced-match: 1.0.2
-      escape-string-regexp: 1.0.5
-      extend: 3.0.2
-      postcss: 8.4.31
-
-  postcss-import@15.1.0(postcss@8.5.8):
-    dependencies:
-      postcss: 8.5.8
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.11
-
-  postcss-js@4.1.0(postcss@8.5.8):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.8
-
   postcss-load-config@3.1.4(postcss@8.5.6):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.5.6
-
-  postcss-load-config@4.0.2(postcss@8.5.8):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.2
-    optionalDependencies:
-      postcss: 8.5.8
 
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.2):
     dependencies:
@@ -8498,11 +7957,6 @@ snapshots:
       jiti: 2.6.1
       postcss: 8.5.8
       yaml: 2.8.2
-
-  postcss-nested@6.2.0(postcss@8.5.8):
-    dependencies:
-      postcss: 8.5.8
-      postcss-selector-parser: 6.1.2
 
   postcss-safe-parser@7.0.1(postcss@8.5.6):
     dependencies:
@@ -8517,23 +7971,10 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.6:
     dependencies:
@@ -8573,12 +8014,6 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  pretty@2.0.0:
-    dependencies:
-      condense-newlines: 0.2.1
-      extend-shallow: 2.0.1
-      js-beautify: 1.15.4
 
   prism-svelte@0.4.7: {}
 
@@ -8631,8 +8066,6 @@ snapshots:
 
   quansync@0.2.11: {}
 
-  queue-microtask@1.2.3: {}
-
   quick-format-unescaped@4.0.4: {}
 
   rc9@3.0.1:
@@ -8663,10 +8096,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
-
   readable-stream@2.3.8:
     dependencies:
       core-util-is: 1.0.3
@@ -8676,10 +8105,6 @@ snapshots:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
-
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -8739,10 +8164,6 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  resend@2.0.0:
-    dependencies:
-      '@react-email/render': 0.0.9
-
   resend@4.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@react-email/render': 1.1.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -8766,8 +8187,6 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
-
-  reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
 
@@ -8834,10 +8253,6 @@ snapshots:
       fsevents: 2.3.3
 
   run-applescript@7.1.0: {}
-
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
 
   runed@0.23.4(svelte@5.55.7(@typescript-eslint/types@8.54.0)):
     dependencies:
@@ -8996,12 +8411,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
-
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -9083,20 +8492,6 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-email-tailwind@4.0.0(@typescript-eslint/types@8.54.0)(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.1.0(svelte@5.36.8(@typescript-eslint/types@8.54.0))(vite@7.3.2(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
-      html-to-text: 9.0.5
-      resend: 2.0.0
-      svelte: 5.36.8(@typescript-eslint/types@8.54.0)
-      svelte-persisted-store: 0.12.0(svelte@5.36.8(@typescript-eslint/types@8.54.0))
-      tw-to-css: 0.0.12
-    transitivePeerDependencies:
-      - '@typescript-eslint/types'
-      - supports-color
-      - ts-node
-      - vite
-
   svelte-eslint-parser@1.4.1(svelte@5.55.7(@typescript-eslint/types@8.54.0)):
     dependencies:
       eslint-scope: 8.4.0
@@ -9122,10 +8517,6 @@ snapshots:
     dependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.54.0)
 
-  svelte-persisted-store@0.12.0(svelte@5.36.8(@typescript-eslint/types@8.54.0)):
-    dependencies:
-      svelte: 5.36.8(@typescript-eslint/types@8.54.0)
-
   svelte-sonner@0.3.28(svelte@5.55.7(@typescript-eslint/types@8.54.0)):
     dependencies:
       svelte: 5.55.7(@typescript-eslint/types@8.54.0)
@@ -9150,25 +8541,6 @@ snapshots:
     dependencies:
       '@formatjs/intl-segmenter': 11.7.12
       svelte: 5.55.7(@typescript-eslint/types@8.54.0)
-
-  svelte@5.36.8(@typescript-eslint/types@8.54.0):
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@types/estree': 1.0.9
-      acorn: 8.16.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      clsx: 2.1.1
-      esm-env: 1.2.2
-      esrap: 2.2.8(@typescript-eslint/types@8.54.0)
-      is-reference: 3.0.3
-      locate-character: 3.0.0
-      magic-string: 0.30.21
-      zimmerframe: 1.1.4
-    transitivePeerDependencies:
-      - '@typescript-eslint/types'
 
   svelte@5.55.7(@typescript-eslint/types@8.54.0):
     dependencies:
@@ -9245,34 +8617,6 @@ snapshots:
       tailwind-merge: 2.5.4
       tailwindcss: 4.1.18
 
-  tailwindcss@3.3.2:
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 2.1.0
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.8
-      postcss-import: 15.1.0(postcss@8.5.8)
-      postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-load-config: 4.0.2(postcss@8.5.8)
-      postcss-nested: 6.2.0(postcss@8.5.8)
-      postcss-selector-parser: 6.1.2
-      postcss-value-parser: 4.2.0
-      resolve: 1.22.11
-      sucrase: 3.35.1
-    transitivePeerDependencies:
-      - ts-node
-
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
@@ -9325,10 +8669,6 @@ snapshots:
   tinyspy@4.0.4: {}
 
   tmp@0.2.5: {}
-
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
 
   toposort@2.0.2:
     optional: true
@@ -9383,14 +8723,6 @@ snapshots:
       - supports-color
       - tsx
       - yaml
-
-  tw-to-css@0.0.12:
-    dependencies:
-      postcss: 8.4.31
-      postcss-css-variables: 0.18.0(postcss@8.4.31)
-      tailwindcss: 3.3.2
-    transitivePeerDependencies:
-      - ts-node
 
   type-check@0.4.0:
     dependencies:
@@ -9747,12 +9079,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.1.2
-
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -9850,7 +9176,8 @@ snapshots:
 
   yaml@1.10.2: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.2:
+    optional: true
 
   yargs-parser@21.1.1: {}
 

--- a/src/lib/components/emails/email-layout.svelte
+++ b/src/lib/components/emails/email-layout.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import { getBaseUrl } from '$lib/constants';
+	import { appName } from '$lib/data/app';
+	import { styles } from '$lib/emails/styles';
+	import { m } from '$lib/paraglide/messages.js';
+
+	type Props = {
+		/** Renders the © / privacy-policy footer. Disable for internal emails. */
+		footer?: boolean;
+		children: Snippet;
+	};
+
+	let { footer = true, children }: Props = $props();
+</script>
+
+<!--
+	Inner email content only. The surrounding <html>/<head>/<body> document shell
+	is added by wrapEmailDocument() in $lib/emails/document.ts — email components
+	can't cleanly emit literal <head>/<body> tags (Svelte reserves those for
+	<svelte:head>/<svelte:body>, which have different semantics).
+-->
+<div style={styles.container}>
+	<img
+		src={`${getBaseUrl()}/logo.png`}
+		alt={appName}
+		width="140"
+		height="140"
+		style={styles.logo}
+	/>
+
+	{@render children()}
+
+	{#if footer}
+		<hr style={styles.hr} />
+		<p style={styles.footer}>
+			©{new Date().getFullYear()}
+			{appName} -
+			<a style={styles.footerLink} href="{getBaseUrl()}/privacy-policy"
+				>{m.crazy_jumpy_mouse_hush()}</a
+			>
+		</p>
+	{/if}
+</div>

--- a/src/lib/emails/document.ts
+++ b/src/lib/emails/document.ts
@@ -1,0 +1,20 @@
+import { getLocale } from '$lib/paraglide/runtime.js';
+
+import { colors, fontFamily } from './styles';
+
+/**
+ * Wraps rendered email body markup in a minimal HTML document shell.
+ *
+ * Email clients ignore <style> blocks, so the structural styles are inlined
+ * here: the <body> carries the page background, font and text color. The email
+ * components themselves only render their inner content (see email-layout.svelte).
+ */
+export const wrapEmailDocument = (head: string, body: string): string =>
+	`<!doctype html><html lang="${getLocale()}"><head>` +
+	`<meta charset="utf-8">` +
+	`<meta name="viewport" content="width=device-width, initial-scale=1.0">` +
+	`<meta name="color-scheme" content="light">` +
+	`<meta name="supported-color-schemes" content="light">` +
+	`${head}</head>` +
+	`<body style="margin:0;padding:0;background-color:${colors.background};font-family:${fontFamily};color:${colors.foreground};">` +
+	`${body}</body></html>`;

--- a/src/lib/emails/email-contact.svelte
+++ b/src/lib/emails/email-contact.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import { Body, Container, Head, Heading, Html, Img, Text } from 'svelte-email-tailwind';
+	import EmailLayout from '$lib/components/emails/email-layout.svelte';
 
-	import { getBaseUrl } from '$lib/constants';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+	import { styles } from './styles';
 
 	type Props = {
 		message: string;
@@ -12,16 +11,9 @@
 	let { message = 'Empty', email }: Props = $props();
 </script>
 
-<Html lang={getLocale()} class="font-sans">
-	<Head />
-	<Body class="bg-background ">
-		<Container class="py-12">
-			<Img src={`${getBaseUrl()}/logo.png`} alt="Logo" width="140" height="140" />
+<EmailLayout footer={false}>
+	<h1 style={styles.heading}>Contact</h1>
 
-			<Heading class="text-primary text-4xl ">Contact</Heading>
-
-			<Text class="mb-10 leading-snug">Message from: {email}</Text>
-			<Text class="mb-10 leading-snug">{message}</Text>
-		</Container>
-	</Body>
-</Html>
+	<p style={styles.lead}>Message from: {email}</p>
+	<p style={styles.lead}>{message}</p>
+</EmailLayout>

--- a/src/lib/emails/email-organization-invitation.svelte
+++ b/src/lib/emails/email-organization-invitation.svelte
@@ -1,21 +1,9 @@
 <script lang="ts">
-	import {
-		Body,
-		Button,
-		Container,
-		Head,
-		Heading,
-		Hr,
-		Html,
-		Img,
-		Link,
-		Text
-	} from 'svelte-email-tailwind';
-
+	import EmailLayout from '$lib/components/emails/email-layout.svelte';
 	import { getBaseUrl } from '$lib/constants';
-	import { appName } from '$lib/data/app';
 	import { m } from '$lib/paraglide/messages.js';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+
+	import { styles } from './styles';
 
 	type Props = {
 		token: string;
@@ -25,32 +13,16 @@
 	let { token = '123456', name = 'Unknown' }: Props = $props();
 </script>
 
-<Html lang={getLocale()} class="font-sans">
-	<Head />
-	<Body class="bg-background">
-		<Container class="py-12">
-			<Img src={`${getBaseUrl()}/logo.png`} alt="Logo" width="140" height="140" />
+<EmailLayout>
+	<h1 style={styles.heading}>{m.calm_loose_midge_scold()}</h1>
 
-			<Heading class="text-primary text-4xl ">{m.calm_loose_midge_scold()}</Heading>
+	<p style={styles.lead}>{m.odd_tense_tuna_list({ name })}</p>
 
-			<Text class="mb-10 text-xl leading-snug">{m.odd_tense_tuna_list({ name })}</Text>
+	<p>
+		<a style={styles.buttonPrimary} href={`${getBaseUrl()}/invite/${token}`}
+			>{m.cool_solid_anaconda_fond()}</a
+		>
+	</p>
 
-			<Button
-				class="bg-primary text-primary-foreground inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium whitespace-nowrap "
-				href={`${getBaseUrl()}/invite/${token}`}>{m.cool_solid_anaconda_fond()}</Button
-			>
-
-			<Text class="text-muted">{m.close_awful_snake_offer()}</Text>
-
-			<Hr class="border-border mt-8" />
-
-			<Text class="text-muted text-xs">
-				©{new Date().getFullYear()}
-				{appName} -
-				<Link class="text-muted" href="{getBaseUrl()}/privacy-policy"
-					>{m.crazy_jumpy_mouse_hush()}</Link
-				>
-			</Text>
-		</Container>
-	</Body>
-</Html>
+	<p style={styles.muted}>{m.close_awful_snake_offer()}</p>
+</EmailLayout>

--- a/src/lib/emails/email-otp-verification.svelte
+++ b/src/lib/emails/email-otp-verification.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import { Body, Container, Head, Heading, Hr, Html, Img, Link, Text } from 'svelte-email-tailwind';
-
-	import { getBaseUrl } from '$lib/constants';
-	import { appName } from '$lib/data/app';
+	import EmailLayout from '$lib/components/emails/email-layout.svelte';
 	import { m } from '$lib/paraglide/messages.js';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+
+	import { styles } from './styles';
 
 	type Props = {
 		code: string;
@@ -13,27 +11,10 @@
 	let { code = '123456' }: Props = $props();
 </script>
 
-<Html lang={getLocale()} class="font-sans">
-	<Head />
-	<Body class="bg-background">
-		<Container class="py-12">
-			<Img src={`${getBaseUrl()}/logo.png`} alt="Logo" width="140" height="140" />
+<EmailLayout>
+	<h1 style={styles.heading}>{m.watery_awful_puffin_nourish()}</h1>
 
-			<Heading class="text-primary text-4xl ">{m.watery_awful_puffin_nourish()}</Heading>
+	<p style={styles.code}>{code}</p>
 
-			<Text class="mb-10 text-xl leading-snug"><code>{code}</code></Text>
-
-			<Text class="text-muted">{m.trite_only_bee_love()}</Text>
-
-			<Hr class="border-border mt-8" />
-
-			<Text class="text-muted text-xs">
-				©{new Date().getFullYear()}
-				{appName} -
-				<Link class="text-muted" href="{getBaseUrl()}/privacy-policy"
-					>{m.crazy_jumpy_mouse_hush()}</Link
-				>
-			</Text>
-		</Container>
-	</Body>
-</Html>
+	<p style={styles.muted}>{m.trite_only_bee_love()}</p>
+</EmailLayout>

--- a/src/lib/emails/email-read-receipt.svelte
+++ b/src/lib/emails/email-read-receipt.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import { Body, Container, Head, Heading, Hr, Html, Img, Link, Text } from 'svelte-email-tailwind';
-
-	import { getBaseUrl } from '$lib/constants';
-	import { appName } from '$lib/data/app';
+	import EmailLayout from '$lib/components/emails/email-layout.svelte';
 	import { m } from '$lib/paraglide/messages.js';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+
+	import { styles } from './styles';
 
 	type Props = {
 		receiptId: string;
@@ -16,32 +14,15 @@
 	let { receiptId = 'ABC123', viewCount = 1, viewLimit = 1, isLastView = true }: Props = $props();
 </script>
 
-<Html lang={getLocale()} class="font-sans">
-	<Head />
-	<Body class="bg-background ">
-		<Container class="py-12">
-			<Img src={`${getBaseUrl()}/logo.png`} alt="Logo" width="140" height="140" />
+<EmailLayout>
+	<h1 style={styles.heading}>{m.slimy_broad_dachshund_lock()} 🔥</h1>
 
-			<Heading class="text-primary text-4xl ">{m.slimy_broad_dachshund_lock()} 🔥</Heading>
+	<p style={styles.lead}>{m.soft_frail_wolf_fear()}</p>
+	<p style={styles.code}>{receiptId}</p>
 
-			<Text class="mb-4 text-xl leading-snug ">{m.soft_frail_wolf_fear()}</Text>
-			<Text class="mb-10 text-xl leading-snug"><code>{receiptId}</code></Text>
-
-			{#if isLastView}
-				<Text class="text-muted">{m.ideal_aloof_mayfly_thrive()}</Text>
-			{:else}
-				<Text class="text-muted">{m.aware_neat_moth_count({ viewCount, viewLimit })}</Text>
-			{/if}
-
-			<Hr class="border-border mt-8" />
-
-			<Text class="text-muted text-xs">
-				©{new Date().getFullYear()}
-				{appName} -
-				<Link class="text-muted" href="{getBaseUrl()}/privacy-policy"
-					>{m.crazy_jumpy_mouse_hush()}</Link
-				>
-			</Text>
-		</Container>
-	</Body>
-</Html>
+	{#if isLastView}
+		<p style={styles.muted}>{m.ideal_aloof_mayfly_thrive()}</p>
+	{:else}
+		<p style={styles.muted}>{m.aware_neat_moth_count({ viewCount, viewLimit })}</p>
+	{/if}
+</EmailLayout>

--- a/src/lib/emails/email-secret-request-response.svelte
+++ b/src/lib/emails/email-secret-request-response.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-	import { Body, Container, Head, Heading, Hr, Html, Img, Link, Text } from 'svelte-email-tailwind';
-
 	import { SECRET_REQUEST_RETENTION_PERIOD_IN_DAYS } from '$lib/client/constants';
-	import { getBaseUrl } from '$lib/constants';
-	import { appName } from '$lib/data/app';
+	import EmailLayout from '$lib/components/emails/email-layout.svelte';
 	import { m } from '$lib/paraglide/messages.js';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+
+	import { styles } from './styles';
 
 	type Props = {
 		receiptId: string;
@@ -14,32 +12,13 @@
 	let { receiptId = 'ABC123' }: Props = $props();
 </script>
 
-<Html lang={getLocale()} class="font-sans">
-	<Head />
-	<Body class="bg-background">
-		<Container class="py-12">
-			<Img src={`${getBaseUrl()}/logo.png`} alt="Logo" width="140" height="140" />
+<EmailLayout>
+	<h1 style={styles.heading}>{m.gold_tidy_crane_heading()}</h1>
 
-			<Heading class="text-primary text-4xl">{m.gold_tidy_crane_heading()}</Heading>
+	<p style={styles.lead}>{m.gold_tidy_crane_body()}</p>
+	<p style={styles.code}>{receiptId}</p>
 
-			<Text class="mb-4 text-xl leading-snug">{m.gold_tidy_crane_body()}</Text>
-			<Text class="mb-10 text-xl leading-snug"><code>{receiptId}</code></Text>
-
-			<Text class="text-muted"
-				>{m.gold_tidy_crane_expiry({
-					retentionPeriod: SECRET_REQUEST_RETENTION_PERIOD_IN_DAYS
-				})}</Text
-			>
-
-			<Hr class="border-border mt-8" />
-
-			<Text class="text-muted text-xs">
-				©{new Date().getFullYear()}
-				{appName} -
-				<Link class="text-muted" href="{getBaseUrl()}/privacy-policy"
-					>{m.crazy_jumpy_mouse_hush()}</Link
-				>
-			</Text>
-		</Container>
-	</Body>
-</Html>
+	<p style={styles.muted}>
+		{m.gold_tidy_crane_expiry({ retentionPeriod: SECRET_REQUEST_RETENTION_PERIOD_IN_DAYS })}
+	</p>
+</EmailLayout>

--- a/src/lib/emails/email-subscription-trial-start.svelte
+++ b/src/lib/emails/email-subscription-trial-start.svelte
@@ -1,22 +1,10 @@
 <script lang="ts">
-	import {
-		Body,
-		Button,
-		Container,
-		Head,
-		Heading,
-		Hr,
-		Html,
-		Img,
-		Link,
-		Text
-	} from 'svelte-email-tailwind';
-
 	import { TRIAL_PERIOD_DAYS } from '$lib/client/constants';
+	import EmailLayout from '$lib/components/emails/email-layout.svelte';
 	import { getBaseUrl } from '$lib/constants';
-	import { appName } from '$lib/data/app';
 	import { m } from '$lib/paraglide/messages.js';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+
+	import { styles } from './styles';
 
 	type Props = {
 		name?: string;
@@ -26,36 +14,19 @@
 	let { name = '', planName = 'TEST' }: Props = $props();
 </script>
 
-<Html lang={getLocale()} class="font-sans">
-	<Head />
-	<Body class="bg-background ">
-		<Container class="py-12">
-			<Img src={`${getBaseUrl()}/logo.png`} alt="Logo" width="140" height="140" />
+<EmailLayout>
+	<h1 style={styles.heading}>{name ? m.honest_quiet_millipede_loop({ name }) : 'Hi there'}</h1>
 
-			<Heading class="text-primary text-4xl "
-				>{name ? m.honest_quiet_millipede_loop({ name }) : 'Hi there'}</Heading
-			>
+	<p style={styles.lead}>{m.pretty_aloof_owl_yell()}</p>
 
-			<Text class="mb-4 text-xl leading-snug">{m.pretty_aloof_owl_yell()}</Text>
+	<p style={styles.text}>{m.dull_flat_loris_bless({ trialPeriod: TRIAL_PERIOD_DAYS })}</p>
+	<p style={styles.text}>{m.still_icy_donkey_fold()} <strong>{planName}</strong></p>
 
-			<Text class="text-lg">{m.dull_flat_loris_bless({ trialPeriod: TRIAL_PERIOD_DAYS })}</Text>
-			<Text class="mb-10  text-lg">{m.still_icy_donkey_fold()} <strong>{planName}</strong></Text>
-
-			<Button
-				class="bg-primary text-primary-foreground inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium whitespace-nowrap "
-				href={`${getBaseUrl()}?utm_source=email&utm_medium=subscription&utm_campaign=new_subscription`}
-				>{m.watery_caring_crab_trim()}</Button
-			>
-
-			<Hr class="border-border mt-8" />
-
-			<Text class="text-muted text-xs">
-				©{new Date().getFullYear()}
-				{appName} -
-				<Link class="text-muted" href="{getBaseUrl()}/privacy-policy"
-					>{m.crazy_jumpy_mouse_hush()}</Link
-				>
-			</Text>
-		</Container>
-	</Body>
-</Html>
+	<p>
+		<a
+			style={styles.buttonPrimary}
+			href={`${getBaseUrl()}?utm_source=email&utm_medium=subscription&utm_campaign=new_subscription`}
+			>{m.watery_caring_crab_trim()}</a
+		>
+	</p>
+</EmailLayout>

--- a/src/lib/emails/email-verification.svelte
+++ b/src/lib/emails/email-verification.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-	import { Container, Head, Heading, Hr, Html, Img, Link, Text } from 'svelte-email-tailwind';
-
-	import { getBaseUrl } from '$lib/constants';
-	import { appName } from '$lib/data/app';
+	import EmailLayout from '$lib/components/emails/email-layout.svelte';
 	import { m } from '$lib/paraglide/messages.js';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+
+	import { styles } from './styles';
 
 	type Props = {
 		code: string;
@@ -13,25 +11,10 @@
 	let { code = '123456' }: Props = $props();
 </script>
 
-<Html lang={getLocale()} class="bg-background font-sans">
-	<Head />
-	<Container class="bg-background py-12">
-		<Img src={`${getBaseUrl()}/logo.png`} alt="Logo" width="140" height="140" />
+<EmailLayout>
+	<h1 style={styles.heading}>{m.watery_awful_puffin_nourish()}</h1>
 
-		<Heading class="text-primary text-4xl ">{m.watery_awful_puffin_nourish()}</Heading>
+	<p style={styles.code}>{code}</p>
 
-		<Text class="mb-10 text-xl leading-snug"><code>{code}</code></Text>
-
-		<Text class="text-muted text-lg">{m.trite_only_bee_love()}</Text>
-
-		<Hr class="border-border mt-8" />
-
-		<Text class="text text-muted">
-			©{new Date().getFullYear()}
-			{appName} -
-			<Link class="text-muted" href="{getBaseUrl()}/privacy-policy"
-				>{m.crazy_jumpy_mouse_hush()}</Link
-			>
-		</Text>
-	</Container>
-</Html>
+	<p style={styles.muted}>{m.trite_only_bee_love()}</p>
+</EmailLayout>

--- a/src/lib/emails/email-welcome.svelte
+++ b/src/lib/emails/email-welcome.svelte
@@ -1,21 +1,9 @@
 <script lang="ts">
-	import {
-		Body,
-		Button,
-		Container,
-		Head,
-		Heading,
-		Hr,
-		Html,
-		Img,
-		Link,
-		Text
-	} from 'svelte-email-tailwind';
-
+	import EmailLayout from '$lib/components/emails/email-layout.svelte';
 	import { getBaseUrl } from '$lib/constants';
-	import { appName } from '$lib/data/app';
 	import { m } from '$lib/paraglide/messages.js';
-	import { getLocale } from '$lib/paraglide/runtime.js';
+
+	import { styles } from './styles';
 
 	type Props = {
 		name?: string;
@@ -27,40 +15,22 @@
 	const PROMO_CODE = 'WELCOMEPROMOTION';
 </script>
 
-<Html lang={getLocale()} class="font-sans">
-	<Head />
-	<Body class="bg-background ">
-		<Container class="py-12">
-			<Img src={`${getBaseUrl()}/logo.png`} alt="Logo" width="140" height="140" />
+<EmailLayout>
+	<h1 style={styles.heading}>{name ? `Hi ${name}` : 'Hi there'}</h1>
 
-			<Heading class="text-primary text-4xl ">{name ? `Hi ${name}` : 'Hi there'}</Heading>
+	<p style={styles.lead}>
+		{m.royal_watery_lionfish_glow()}
+		<strong>{m.stock_round_finch_support()}</strong>
+	</p>
 
-			<Text class="mb-4 text-xl leading-snug"
-				>{m.royal_watery_lionfish_glow()}
-				<strong>{m.stock_round_finch_support()}</strong>
-			</Text>
+	<p style={styles.text}>{m.welcome_email_promo()}</p>
+	<p style={styles.tag}>{PROMO_CODE}</p>
 
-			<Text class="mb-2 text-lg">{m.welcome_email_promo()}</Text>
-			<Text
-				class="border-border text-foreground mb-10 inline-block rounded-md border px-4 py-2 text-lg font-bold tracking-widest"
-				>{PROMO_CODE}</Text
-			>
-
-			<Button
-				class="bg-background text-foreground border-foreground inline-flex items-center justify-center rounded-md border  px-4 py-2 text-sm font-medium whitespace-nowrap "
-				href={`${getBaseUrl()}/pricing?utm_source=email&utm_medium=welcome&utm_campaign=new_signup`}
-				>{m.antsy_moving_hare_bloom()}</Button
-			>
-
-			<Hr class="border-border mt-8" />
-
-			<Text class="text-muted text-xs">
-				©{new Date().getFullYear()}
-				{appName} -
-				<Link class="text-muted" href="{getBaseUrl()}/privacy-policy"
-					>{m.crazy_jumpy_mouse_hush()}</Link
-				>
-			</Text>
-		</Container>
-	</Body>
-</Html>
+	<p>
+		<a
+			style={styles.buttonOutline}
+			href={`${getBaseUrl()}/pricing?utm_source=email&utm_medium=welcome&utm_campaign=new_signup`}
+			>{m.antsy_moving_hare_bloom()}</a
+		>
+	</p>
+</EmailLayout>

--- a/src/lib/emails/styles.ts
+++ b/src/lib/emails/styles.ts
@@ -1,0 +1,44 @@
+// Shared inline styles for transactional emails.
+//
+// Email clients strip <style> blocks and ignore class-based CSS, so every style
+// must be inlined on the element. These tokens keep the templates consistent
+// without pulling in a Tailwind-to-inline build step.
+//
+// Colors are static hex resolved from the app design system (src/app.css). Email
+// clients don't support CSS variables, oklch() or contrast-color(), so the values
+// are flattened here for the light theme.
+
+export const colors = {
+	background: '#faf8f5', // --background (cream)
+	foreground: '#0f1b2e', // --foreground (deep navy)
+	primary: '#1a2942', // --primary (navy)
+	primaryForeground: '#ffffff', // contrast-color(--primary)
+	mutedForeground: '#404e64', // --muted-foreground (slate)
+	card: '#fffdfa', // --card (cream-white)
+	border: '#d6d4d0' // --border (warm tan)
+};
+
+// Font names are single-quoted so the stack can be embedded in a double-quoted
+// HTML style attribute (see wrapEmailDocument) without terminating it early.
+export const fontFamily =
+	"-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif";
+
+export const styles = {
+	// Font + color repeated on the container so the email still styles correctly
+	// in clients that strip <body> styles (e.g. Gmail).
+	container: `max-width:600px;margin:0 auto;padding:48px 24px;font-family:${fontFamily};color:${colors.foreground};`,
+	logo: `display:block;margin-bottom:24px;`,
+	heading: `margin:0 0 16px;font-size:32px;line-height:1.15;font-weight:700;color:${colors.foreground};`,
+	lead: `margin:0 0 16px;font-size:20px;line-height:1.4;color:${colors.foreground};`,
+	text: `margin:0 0 16px;font-size:16px;line-height:1.5;color:${colors.foreground};`,
+	muted: `margin:0 0 16px;font-size:16px;line-height:1.5;color:${colors.mutedForeground};`,
+	// Monospace box used for OTP codes / receipt IDs.
+	code: `display:inline-block;margin:0 0 24px;padding:8px 16px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:22px;font-weight:700;letter-spacing:0.15em;color:${colors.foreground};background-color:${colors.card};border:1px solid ${colors.border};border-radius:6px;`,
+	// Highlighted value inline in a paragraph (e.g. promo code).
+	tag: `display:inline-block;margin:0 0 32px;padding:8px 16px;font-size:18px;font-weight:700;letter-spacing:0.1em;color:${colors.foreground};border:1px solid ${colors.border};border-radius:6px;`,
+	buttonPrimary: `display:inline-block;padding:12px 20px;font-size:14px;font-weight:500;line-height:1;text-decoration:none;border-radius:6px;color:${colors.primaryForeground};background-color:${colors.primary};`,
+	buttonOutline: `display:inline-block;padding:12px 20px;font-size:14px;font-weight:500;line-height:1;text-decoration:none;border-radius:6px;color:${colors.foreground};background-color:${colors.background};border:1px solid ${colors.foreground};`,
+	hr: `margin:32px 0 16px;border:none;border-top:1px solid ${colors.border};`,
+	footer: `margin:0;font-size:12px;line-height:1.5;color:${colors.mutedForeground};`,
+	footerLink: `color:${colors.mutedForeground};`
+};

--- a/src/lib/server/transactional-email.ts
+++ b/src/lib/server/transactional-email.ts
@@ -1,6 +1,7 @@
 import { render } from 'svelte/server';
 
 import { emailSupport } from '$lib/data/app';
+import { wrapEmailDocument } from '$lib/emails/document';
 import EmailContact from '$lib/emails/email-contact.svelte';
 import EmailOrganizationInvitation from '$lib/emails/email-organization-invitation.svelte';
 import EmailOtpVerification from '$lib/emails/email-otp-verification.svelte';
@@ -13,30 +14,30 @@ import { m } from '$lib/paraglide/messages.js';
 import sendTransactionalEmail from './resend';
 
 export const sendVerificationEmail = async (email: string, code: string) => {
-	const { html } = render(EmailOtpVerification, { props: { code } });
+	const { head, body } = render(EmailOtpVerification, { props: { code } });
 	await sendTransactionalEmail({
 		subject: m.sunny_this_falcon_coax(),
 		to: email,
-		html: html
+		html: wrapEmailDocument(head, body)
 	});
 	console.log(`To ${email}: Your verification code is ${code}`);
 };
 
 export const sendWelcomeEmail = async (email: string, name?: string) => {
-	const { html } = render(EmailWelcome, { props: { name } });
+	const { head, body } = render(EmailWelcome, { props: { name } });
 	await sendTransactionalEmail({
 		subject: m.pink_crisp_snail_flow(),
 		to: email,
-		html: html
+		html: wrapEmailDocument(head, body)
 	});
 };
 
 export const sendContactEmail = async (email: string, content: string) => {
-	const { html } = render(EmailContact, { props: { message: content, email } });
+	const { head, body } = render(EmailContact, { props: { message: content, email } });
 	await sendTransactionalEmail({
 		subject: `New message from ${email}`,
 		to: emailSupport,
-		html: html
+		html: wrapEmailDocument(head, body)
 	});
 };
 
@@ -47,13 +48,13 @@ export const sendReadReceiptEmail = async (
 	viewLimit: number,
 	isLastView: boolean
 ) => {
-	const { html } = render(EmailReadReceipt, {
+	const { head, body } = render(EmailReadReceipt, {
 		props: { receiptId, viewCount, viewLimit, isLastView }
 	});
 	await sendTransactionalEmail({
 		subject: m.slimy_broad_dachshund_lock(),
 		to: email,
-		html: html
+		html: wrapEmailDocument(head, body)
 	});
 	console.log(`Send read receipt to ${email}.`);
 };
@@ -63,20 +64,20 @@ export const sendSubscriptionTrialStartEmail = async (
 	planName: string,
 	name?: string
 ) => {
-	const { html } = render(EmailSubscriptionTrialStart, { props: { planName, name } });
+	const { head, body } = render(EmailSubscriptionTrialStart, { props: { planName, name } });
 	await sendTransactionalEmail({
 		subject: m.level_every_chicken_fall(),
 		to: email,
-		html
+		html: wrapEmailDocument(head, body)
 	});
 };
 
 export const sendSecretRequestResponseReceiptEmail = async (email: string, receiptId: string) => {
-	const { html } = render(EmailSecretRequestResponse, { props: { receiptId } });
+	const { head, body } = render(EmailSecretRequestResponse, { props: { receiptId } });
 	await sendTransactionalEmail({
 		subject: m.gold_tidy_crane_subject(),
 		to: email,
-		html
+		html: wrapEmailDocument(head, body)
 	});
 	console.log(`Send secret request response notification to ${email}.`);
 };
@@ -86,13 +87,13 @@ export const sendOrganisationInvitationEmail = async (
 	token: string,
 	organizationName: string
 ) => {
-	const { html } = render(EmailOrganizationInvitation, {
+	const { head, body } = render(EmailOrganizationInvitation, {
 		props: { token, name: organizationName }
 	});
 	await sendTransactionalEmail({
 		subject: m.formal_each_zebra_pull({ name: organizationName }),
 		to: email,
-		html: html
+		html: wrapEmailDocument(head, body)
 	});
 	console.log(`To ${email}:  Invitation OTP-token is ${token}`);
 };

--- a/src/routes/(app)/(default)/account/admin/email-previews/+page.server.ts
+++ b/src/routes/(app)/(default)/account/admin/email-previews/+page.server.ts
@@ -1,14 +1,53 @@
-import { createEmail, emailList, sendEmail } from 'svelte-email-tailwind/preview';
+import { fail } from '@sveltejs/kit';
+import type { Component } from 'svelte';
+import { render } from 'svelte/server';
 
-import { RESEND_API } from '$env/static/private';
+import { wrapEmailDocument } from '$lib/emails/document';
+import sendTransactionalEmail from '$lib/server/resend';
+
+// Auto-discover every transactional email template. Each renders with its own
+// built-in default props (see the templates in $lib/emails).
+const modules = import.meta.glob<{ default: Component }>('$lib/emails/*.svelte', {
+	eager: true
+});
+
+const emails = new Map<string, Component>(
+	Object.entries(modules).map(([path, mod]) => [
+		path.split('/').pop()!.replace('.svelte', ''),
+		mod.default
+	])
+);
+
+const renderEmail = (name: string): string | null => {
+	const component = emails.get(name);
+	if (!component) return null;
+	const { head, body } = render(component, { props: {} });
+	return wrapEmailDocument(head, body);
+};
 
 export async function load() {
-	// return the list of email components
-	return { previewData: emailList() };
+	const previews = [...emails.keys()].sort().map((name) => ({ name, html: renderEmail(name)! }));
+
+	return { previews };
 }
 
 export const actions = {
-	// Pass in the two actions. Provide your Resend API key.
-	...createEmail,
-	...sendEmail({ resendApiKey: RESEND_API })
+	send: async ({ request }) => {
+		const data = await request.formData();
+		const name = String(data.get('name') ?? '');
+		const to = String(data.get('to') ?? '');
+
+		if (!to) {
+			return fail(400, { error: 'Please enter a recipient email address.' });
+		}
+
+		const html = renderEmail(name);
+		if (!html) {
+			return fail(400, { error: `Unknown email template: ${name}` });
+		}
+
+		await sendTransactionalEmail({ to, subject: `[Preview] ${name}`, html });
+
+		return { success: true, name, to };
+	}
 };

--- a/src/routes/(app)/(default)/account/admin/email-previews/+page.svelte
+++ b/src/routes/(app)/(default)/account/admin/email-previews/+page.svelte
@@ -1,9 +1,85 @@
 <script lang="ts">
-	import PreviewInterface from 'svelte-email-tailwind/preview/PreviewInterface.svelte';
+	import { enhance } from '$app/forms';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import { localizeHref } from '$lib/paraglide/runtime';
 
-	import type { PageData } from './$types';
+	import type { ActionData, PageData } from './$types';
 
-	let { data }: { data: PageData } = $props();
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	let selected = $state('');
+	let sending = $state(false);
+
+	// Falls back to the first template until one is explicitly selected.
+	const current = $derived(
+		data.previews.find((preview) => preview.name === selected) ?? data.previews[0]
+	);
 </script>
 
-<PreviewInterface data={data.previewData} email="info@scrt.link" />
+<div class="mb-6">
+	<Button variant="outline" href={localizeHref('/account/admin')}>← Back to admin</Button>
+</div>
+
+<h1 class="mb-4 text-2xl font-bold">Email previews</h1>
+
+{#if data.previews.length === 0}
+	<p class="text-muted-foreground">No email templates found in <code>$lib/emails</code>.</p>
+{:else}
+	<div class="grid gap-6 md:grid-cols-[220px_1fr]">
+		<nav class="flex flex-col gap-1">
+			{#each data.previews as preview (preview.name)}
+				<button
+					type="button"
+					class="rounded-md px-3 py-2 text-left text-sm transition-colors {current?.name ===
+					preview.name
+						? 'bg-primary text-primary-foreground'
+						: 'hover:bg-muted'}"
+					onclick={() => (selected = preview.name)}
+				>
+					{preview.name}
+				</button>
+			{/each}
+		</nav>
+
+		<div>
+			{#if current}
+				<div class="mb-4 overflow-hidden rounded-lg border">
+					<iframe title={current.name} srcdoc={current.html} class="h-[640px] w-full bg-white"
+					></iframe>
+				</div>
+
+				<form
+					method="POST"
+					action="?/send"
+					class="flex flex-wrap items-center gap-2"
+					use:enhance={() => {
+						sending = true;
+						return async ({ update }) => {
+							await update();
+							sending = false;
+						};
+					}}
+				>
+					<input type="hidden" name="name" value={current.name} />
+					<Input
+						type="email"
+						name="to"
+						placeholder="recipient@example.com"
+						required
+						class="max-w-xs"
+					/>
+					<Button type="submit" disabled={sending}>
+						{sending ? 'Sending…' : 'Send test'}
+					</Button>
+				</form>
+
+				{#if form?.success}
+					<p class="text-success mt-2 text-sm">Sent “{form.name}” to {form.to}.</p>
+				{:else if form?.error}
+					<p class="text-destructive mt-2 text-sm">{form.error}</p>
+				{/if}
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,31 +3,9 @@ import svg from '@poppanator/sveltekit-svg';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import fs from 'fs';
-import svelteEmailTailwind from 'svelte-email-tailwind/vite';
 import { searchForWorkspaceRoot } from 'vite';
 import { defineConfig } from 'vitest/config';
 
-const config = {
-	theme: {
-		fontFamily: {
-			sans: [
-				'-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif'
-			]
-		},
-		extend: {
-			colors: {
-				border: '#e5e7eb',
-				muted: '#5c5c5c',
-				background: '#f5f5f5',
-				foreground: '#2e2e38',
-				primary: {
-					DEFAULT: '#e60077',
-					foreground: '#ffffff'
-				}
-			}
-		}
-	}
-};
 const httpsConfig = fs.existsSync('./wl.scrt.link-key.pem')
 	? { key: fs.readFileSync('./wl.scrt.link-key.pem'), cert: fs.readFileSync('./wl.scrt.link.pem') }
 	: undefined;
@@ -52,7 +30,6 @@ export default defineConfig({
 			// disableAsyncLocalStorage: true // Only Vercel
 		}),
 		sveltekit(),
-		svelteEmailTailwind({ tailwindConfig: config }),
 		svg(),
 		tailwindcss()
 	]


### PR DESCRIPTION
## Problem

Transactional emails rendered unstyled (buttons showed as plain text/links). Root cause: the `svelte-email-tailwind` Vite plugin only inlines Tailwind for files under its default `pathToEmailFolder` (`/src/emails`), but our templates live in `/src/lib/emails` and the config never overrode that path — so the class→inline-style transform **never ran**. The library is also fragile (Svelte-4 components, a regex parser over compiled Svelte-5 output, a leftover `console.log` on every transform).

## Change

Drop `svelte-email-tailwind` entirely and use plain inline-CSS email components.

- **All 8 templates** rewritten with vanilla inline styles + a shared `EmailLayout` and style tokens (`src/lib/emails/styles.ts`).
- **Document shell in code** (`src/lib/emails/document.ts` → `wrapEmailDocument`): the components render inner content only, because Svelte reserves `<head>`/`<body>` for `<svelte:head>`/`<svelte:body>` (which have different semantics and break email rendering). Font/color are repeated on the container so it survives clients that strip `<body>` styles.
- **Palette aligned with the post-redesign design system** — navy on cream; the legacy pink is gone. Hex values were read from the running app's computed styles (the design uses `oklch(from …)` + CSS vars + `contrast-color()`, none email-safe).
- **Dependency + Vite plugin removed** (−74 transitive packages).
- **Admin email-previews page rebuilt** without the library: `import.meta.glob` discovery + `svelte/server` `render()`, iframe `srcdoc` preview, and "send test" via the app's own Resend helper (so tests use the real `from` address).

## Verification

- Rendered every template through the real `render()` path and inspected in-browser (welcome outline button, filled navy button, OTP code box — all correct, sans-serif, cream/navy). Screenshots in the PR thread / conversation.
- `pnpm check`: no errors in any touched file (project total 46→45).
- `pnpm build`: passes (Vercel adapter).

## Base

Targets `feat/welcome-wizard` (not `dev`) because the welcome template uses `m.welcome_email_promo()`, a key introduced by that branch and not yet in `dev`. It reaches `dev` when the wizard branch merges.

## Note

`sendTransactionalEmail` swallows Resend errors internally, so the preview page's "Sent" confirmation is optimistic (a failed send won't surface an error). Matches existing behaviour; can wire up real feedback if wanted.