### PR TITLE
docs(legal): correct GDPR, privacy & cookie policies to match the product

### DIFF
--- a/src/lib/assets/terms/CookiePolicy.md
+++ b/src/lib/assets/terms/CookiePolicy.md
@@ -1,4 +1,4 @@
-Last Updated April 29, 2025
+Last Updated 13 July 2026
 
 We use cookies to help improve your experience of our website at [https://scrt.link](https://scrt.link). This cookie policy is part of SANTiHANS GmbH's privacy policy. It covers the use of cookies between your device and our site.
 
@@ -34,7 +34,10 @@ We do not use this type of cookie on our site.
 
 Functionality cookies are used to collect information about your device and any settings you may configure on the website you’re visiting (like language and time zone settings). With this information, websites can provide you with customized, enhanced, or optimized content and services. These cookies may be set by the website you’re visiting (first-party) or by third-party services.
 
-We do not use this type of cookie on our site.
+We use functionality cookies to:
+
+- Remember your language preference (first-party).
+- Enable secure payment processing and fraud prevention through Stripe, our payment provider, on pages that offer payment functionality (third-party). See [Stripe's cookie policy](https://stripe.com/legal/cookies-policy) for details.
 
 ### Targeting/advertising cookies
 

--- a/src/lib/assets/terms/GDPR.md
+++ b/src/lib/assets/terms/GDPR.md
@@ -13,9 +13,7 @@ We collect and store the following personal information when you sign up for or 
 - Email address
 - Name (optional)
 
-Additionally, for security and operational monitoring, we collect:
-
-- IP addresses of users visiting scrt.link
+We do not store IP addresses. For security and abuse prevention (e.g. rate limiting), IP addresses may be processed transiently and appear in our hosting provider's server logs, where they are retained only briefly before being discarded.
 
 ---
 
@@ -37,6 +35,8 @@ Used for processing payments. Card data is never stored on our systems.
 Data shared:
 
 - Email address
+- Name (optional — only if provided)
+- Organization (optional — only if provided)
 
 [Stripe GDPR Compliance](https://stripe.com/guides/general-data-protection-regulation)
 
@@ -52,6 +52,19 @@ Data shared:
 - Name (if available)
 
 [Brevo GDPR Compliance](https://www.brevo.com/gdpr/)
+
+---
+
+### **Google**
+
+Used for authentication only if you choose to sign in with Google as your identity provider. In that case, Google provides us with your email address and name to create or access your account, and processes the sign-in on their systems. If you sign up with an email and password instead, no data is exchanged with Google.
+
+Data involved:
+
+- Email address
+- Name
+
+[Google Privacy Policy](https://policies.google.com/privacy)
 
 ---
 
@@ -83,7 +96,7 @@ We use your data to:
 
 We store your data only for as long as your account is active.
 
-If you delete your account, all personal data is automatically and permanently erased within **30 days**, except where legal obligations (e.g., invoicing) require longer retention.
+When you delete your account, your personal data is erased from our active systems immediately. Any residual copies in encrypted backups are purged within **30 days**. We retain limited records (e.g., invoices) only where legal obligations require it.
 
 ---
 

--- a/src/lib/assets/terms/PrivacyPolicy.md
+++ b/src/lib/assets/terms/PrivacyPolicy.md
@@ -6,7 +6,7 @@ In the event our site contains links to third-party sites and services, please b
 
 This policy is effective as of 31 May 2021.
 
-Last updated: 31 May 2021
+Last updated: 13 July 2026
 
 ## Information We Collect
 
@@ -30,13 +30,10 @@ We may ask for personal information — for example, when you register an accoun
 
 - Name
 - Email
-- Phone/mobile number
 
 ### User-Generated Content
 
-We consider “user-generated content” to be materials (text, image and/or video content) voluntarily supplied to us by our users for the purpose of publication, processing, or usage on our platform. All user-generated content is associated with the account or email address used to submit the materials.
-
-Please be aware that any content you submit for the purpose of publication will be public after posting (and subsequent review or vetting process). Once published, it may be accessible to third parties not covered under this privacy policy.
+We consider “user-generated content” to be the secrets and files you create and share through our service. This content is end-to-end encrypted on your device before it reaches us: we cannot read or access its contents, and it is never published or made publicly available. Encrypted content is stored only until it is retrieved by the intended recipient or until it expires, after which it is permanently deleted.
 
 ### Transaction Data
 
@@ -100,6 +97,7 @@ Third parties we currently use include:
 - Plausible - https://plausible.io/
 - Stripe - https://stripe.com/
 - Brevo - https://www.brevo.com/
+- Google (authentication, only if you sign in with Google) - https://policies.google.com/privacy
 
 ## Your Rights and Controlling Your Personal Information
 
@@ -123,7 +121,7 @@ Third parties we currently use include:
 
 ## Use of Cookies
 
-We use “cookies” to collect information about you and your activity across our site. A cookie is a small piece of data that our website stores on your computer, and accesses each time you visit, so we can understand how you use our site. This helps us serve you content based on preferences you have specified.
+A cookie is a small piece of data that our website stores on your device. We only use cookies that are strictly necessary to operate our service — for example, to keep you signed in, to secure your session, and to protect against abuse. We do not use advertising or cross-site tracking cookies, and our analytics are privacy-friendly and do not rely on cookies.
 
 Please refer to our Cookie Policy for more information.
 
@@ -189,7 +187,7 @@ We will ensure that any transfer of personal information from countries in the E
 
 **Data portability:** You may have the right to request a copy of the personal information we hold about you. Where possible, we will provide this information in CSV format or other easily readable machine format. You may also have the right to request that we transfer this personal information to a third party.
 
-**Deletion:** You may have a right to request that we delete the personal information we hold about you at any time, and we will take reasonable steps to delete your personal information from our current records. If you ask us to delete your personal information, we will let you know how the deletion affects your use of our website or products and services. There may be exceptions to this right for specific legal reasons which, if applicable, we will set out for you in response to your request. If you terminate or delete your account, we will delete your personal information within 3 days of the deletion of your account. Please be aware that search engines and similar third parties may still retain copies of your personal information that has been made public at least once, like certain profile information and public comments, even after you have deleted the information from our services or deactivated your account.
+**Deletion:** You may have a right to request that we delete the personal information we hold about you at any time, and we will take reasonable steps to delete your personal information from our current records. If you ask us to delete your personal information, we will let you know how the deletion affects your use of our website or products and services. There may be exceptions to this right for specific legal reasons which, if applicable, we will set out for you in response to your request. If you terminate or delete your account, your personal information is erased from our active systems immediately, and any residual copies in encrypted backups are purged within 30 days. We may retain limited records (for example, invoices) where required by law, or for accounting or reporting obligations.
 
 ## Additional Disclosures for California Compliance (US)
 


### PR DESCRIPTION
Reviewed the legal documents against actual data handling in the codebase and corrected inaccuracies and inconsistencies between them.

## GDPR (`GDPR.md`)
- Added **Google** as a third party, scoped to "only if you sign in with Google" (OAuth via Arctic).
- Extended **Stripe** shared data to include Name and Organization, both flagged optional.
- Removed the "we collect IP addresses" claim — the app doesn't store IPs (rate limiter only persists a hash; no `ip` column). Reworded to reflect transient processing for rate limiting and short-lived hosting-provider (Vercel) logs.
- Harmonized data-retention wording with the Privacy Policy.

## Privacy Policy (`PrivacyPolicy.md`)
- Rewrote the **User-Generated Content** section — it claimed content becomes "public after posting", which contradicts the zero-knowledge model. Now states secrets/files are E2E-encrypted, never published, deleted after retrieval/expiry.
- Fixed **account-deletion** timing: was "within 3 days" (Privacy Policy) vs "30 days" (GDPR) vs immediate (actual code). Now: immediate erasure from active systems, backups purged within 30 days, legal-record carve-out — consistent across both docs.
- Removed **Phone/mobile number** from collected data (never collected).
- Scoped the **cookies** description to functional-only (no tracking/advertising cookies; cookieless analytics).
- Added **Google** to the third-parties list for parity with the GDPR page.
- Bumped last-updated date.

## Cookie Policy (`CookiePolicy.md`)
- **Functionality cookies** changed from "we do not use" to reflect actual usage: language preference (first-party `PARAGLIDE_LOCALE`) and Stripe fraud-prevention cookies (third-party, on payment pages).
- Bumped last-updated date.

Essential / Performance / Targeting sections were left as-is (verified accurate).

> [!NOTE]
> Two judgment calls to confirm with legal:
> 1. Stripe's fraud-prevention cookies are filed under **Functionality** (consent-requiring) rather than Essential. If a consent banner exists, Stripe should be gated behind consent on payment pages to stay consistent.
> 2. The 30-day backup-purge figure assumes the DB/host backup retention window is ≤30 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)