### PR TITLE
feat(api-keys): allow organizations to create API keys

### DIFF
--- a/messages/da.json
+++ b/messages/da.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Databehandleraftale (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Generér en databehandleraftale (DPA) til scrt.link, klar til underskrift. I overensstemmelse med GDPR og schweiziske FADP.",
 	"dpa_your_details": "Virksomhedsoplysninger",
 	"dpa_field_company_name": "Juridisk virksomhedsnavn",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Kan jeg bruge scrt.link anonymt?",
 	"privacy_faq_anonymous_a": "Ja. At oprette og dele en hemmelighed kræver hverken konto eller personoplysninger. En konto er valgfri og låser kun op for yderligere funktioner.",
 	"privacy_policy_cta_title": "Den fulde juridiske version",
-	"privacy_policy_cta_lead": "Vil du have alle detaljer? Læs vores komplette privatlivspolitik."
+	"privacy_policy_cta_lead": "Vil du have alle detaljer? Læs vores komplette privatlivspolitik.",
+	"teaser_org_api_title": "Automatiser deling af hemmeligheder for din organisation",
+	"teaser_org_api_description": "Opgrader til Top Secret Service for at oprette API-nøgler for hele organisationen og generere hemmeligheder programmatisk fra dine egne applikationer.",
+	"org_api_keys_card_description": "Opret API-nøgler til din organisation. Alle ejere og administratorer kan oprette og tilbagekalde dem.",
+	"org_api_keys_domain_title": "Nøglerne er begrænset til dit domæne",
+	"org_api_keys_domain_description": "Organisationens API-nøgler virker kun for hemmeligheder, der oprettes på {domain}. Angiv det som host-indstillingen i klientmodulet – eller som X-Host-header ved direkte API-kald.",
+	"org_api_keys_no_domain_title": "Intet white-label-domæne konfigureret",
+	"org_api_keys_no_domain_description": "Organisationens API-nøgler er begrænset til organisationens white-label-domæne. Opsæt et eget domæne først – indtil da kan nøgler, du opretter her, ikke oprette hemmeligheder.",
+	"org_api_keys_no_domain_cta": "Opsæt white-label-domæne",
+	"org_api_keys_plan_required_title": "Opgradering af plan påkrævet",
+	"org_api_keys_plan_required_description": "API-nøgler til organisationer kræver Top Secret Service-planen.",
+	"org_api_keys_limit_description": "Der er tilladt maksimalt {amount} API-nøgler pr. organisation. For at oprette en ny nøgle skal du tilbagekalde en eksisterende."
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "AVV",
 	"dpa_title": "Auftragsverarbeitungsvertrag (AVV)",
+	"dpa_title_short": "AVV",
 	"dpa_lead": "Auftragsverarbeitungsvertrag (AVV) für scrt.link erstellen – unterschriftsreif. Konform mit DSGVO und dem Schweizer DSG.",
 	"dpa_your_details": "Angaben zum Unternehmen",
 	"dpa_field_company_name": "Rechtlicher Firmenname",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Lässt sich scrt.link anonym nutzen?",
 	"privacy_faq_anonymous_a": "Ja. Für das Erstellen und Teilen eines Secrets sind kein Konto und keine personenbezogenen Daten erforderlich. Ein Konto ist optional und schaltet nur zusätzliche Funktionen frei.",
 	"privacy_policy_cta_title": "Die vollständige rechtliche Fassung",
-	"privacy_policy_cta_lead": "Alle Details gewünscht? Die vollständige Datenschutzerklärung ist hier verfügbar."
+	"privacy_policy_cta_lead": "Alle Details gewünscht? Die vollständige Datenschutzerklärung ist hier verfügbar.",
+	"teaser_org_api_title": "Geheimnis-Sharing für die Organisation automatisieren",
+	"teaser_org_api_description": "Upgrade auf Top Secret Service, um organisationsweite API-Schlüssel zu erstellen und Geheimnisse programmgesteuert aus eigenen Anwendungen zu generieren.",
+	"org_api_keys_card_description": "API-Schlüssel für die Organisation erstellen. Alle Eigentümer und Administratoren können sie erstellen und widerrufen.",
+	"org_api_keys_domain_title": "Schlüssel sind auf die eigene Domain beschränkt",
+	"org_api_keys_domain_description": "API-Schlüssel der Organisation funktionieren nur für Geheimnisse, die auf {domain} erstellt werden. Die Domain wird als host-Option im Client-Modul gesetzt – oder als X-Host-Header bei direkten API-Aufrufen.",
+	"org_api_keys_no_domain_title": "Keine White-Label-Domain konfiguriert",
+	"org_api_keys_no_domain_description": "API-Schlüssel der Organisation sind auf die White-Label-Domain der Organisation beschränkt. Zuerst muss eine eigene Domain eingerichtet werden – bis dahin können hier erstellte Schlüssel keine Geheimnisse anlegen.",
+	"org_api_keys_no_domain_cta": "White-Label-Domain einrichten",
+	"org_api_keys_plan_required_title": "Plan-Upgrade erforderlich",
+	"org_api_keys_plan_required_description": "API-Schlüssel für Organisationen erfordern den Plan Top Secret Service.",
+	"org_api_keys_limit_description": "Pro Organisation sind maximal {amount} API-Schlüssel erlaubt. Um einen neuen Schlüssel zu erstellen, bitte einen bestehenden widerrufen."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Can I use scrt.link anonymously?",
 	"privacy_faq_anonymous_a": "Yes. Creating and sharing a secret requires no account and no personal information. An account is optional and only unlocks additional features.",
 	"privacy_policy_cta_title": "The full legal version",
-	"privacy_policy_cta_lead": "Want every detail? Read our complete privacy policy."
+	"privacy_policy_cta_lead": "Want every detail? Read our complete privacy policy.",
+	"teaser_org_api_title": "Automate Secret Sharing for Your Organization",
+	"teaser_org_api_description": "Upgrade to Top Secret Service to create organization-wide API keys and generate secrets programmatically from your own applications.",
+	"org_api_keys_card_description": "Create API keys for your organization. Any owner or admin can create and revoke them.",
+	"org_api_keys_domain_title": "Keys are restricted to your domain",
+	"org_api_keys_domain_description": "Organization API keys only work for secrets created on {domain}. Set it as the host option in the client module — or as the X-Host header when calling the API directly.",
+	"org_api_keys_no_domain_title": "No white-label domain configured",
+	"org_api_keys_no_domain_description": "Organization API keys are restricted to your organization's white-label domain. Set up a custom domain first — until then, keys you create here won't be able to create secrets.",
+	"org_api_keys_no_domain_cta": "Set up white-label domain",
+	"org_api_keys_plan_required_title": "Plan upgrade required",
+	"org_api_keys_plan_required_description": "Organization API keys require the Top Secret Service plan.",
+	"org_api_keys_limit_description": "A maximum of {amount} API keys is allowed per organization. To create a new key, please revoke an existing one."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Acuerdo de Tratamiento de Datos (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Generar un Acuerdo de Tratamiento de Datos (DPA) para scrt.link, listo para firmar. Conforme con el GDPR y la FADP suiza.",
 	"dpa_your_details": "Datos de la empresa",
 	"dpa_field_company_name": "Nombre legal de la empresa",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "¿Puedo usar scrt.link de forma anónima?",
 	"privacy_faq_anonymous_a": "Sí. Crear y compartir un secreto no requiere ninguna cuenta ni información personal. La cuenta es opcional y solo desbloquea funciones adicionales.",
 	"privacy_policy_cta_title": "La versión legal completa",
-	"privacy_policy_cta_lead": "¿Quieres todos los detalles? Lee nuestra política de privacidad completa."
+	"privacy_policy_cta_lead": "¿Quieres todos los detalles? Lee nuestra política de privacidad completa.",
+	"teaser_org_api_title": "Automatiza el intercambio de secretos de tu organización",
+	"teaser_org_api_description": "Pasa a Top Secret Service para crear claves API para toda la organización y generar secretos de forma programática desde tus propias aplicaciones.",
+	"org_api_keys_card_description": "Crea claves API para tu organización. Cualquier propietario o administrador puede crearlas y revocarlas.",
+	"org_api_keys_domain_title": "Las claves están restringidas a tu dominio",
+	"org_api_keys_domain_description": "Las claves API de la organización solo funcionan para secretos creados en {domain}. Indícalo como opción host en el módulo cliente, o como cabecera X-Host si llamas a la API directamente.",
+	"org_api_keys_no_domain_title": "No hay dominio white-label configurado",
+	"org_api_keys_no_domain_description": "Las claves API de la organización están restringidas al dominio white-label de tu organización. Configura primero un dominio propio; hasta entonces, las claves que crees aquí no podrán crear secretos.",
+	"org_api_keys_no_domain_cta": "Configurar dominio white-label",
+	"org_api_keys_plan_required_title": "Se requiere una mejora de plan",
+	"org_api_keys_plan_required_description": "Las claves API de organización requieren el plan Top Secret Service.",
+	"org_api_keys_limit_description": "Se permite un máximo de {amount} claves API por organización. Para crear una nueva clave, revoca una existente."
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Accord de traitement des données (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Générer un accord de traitement des données (DPA) pour scrt.link, prêt à signer. Conforme au GDPR et à la FADP suisse.",
 	"dpa_your_details": "Coordonnées de l’entreprise",
 	"dpa_field_company_name": "Raison sociale",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Puis-je utiliser scrt.link de manière anonyme ?",
 	"privacy_faq_anonymous_a": "Oui. Créer et partager un secret ne nécessite ni compte ni informations personnelles. Un compte est facultatif et ne débloque que des fonctionnalités supplémentaires.",
 	"privacy_policy_cta_title": "La version juridique complète",
-	"privacy_policy_cta_lead": "Vous voulez tous les détails ? Consultez notre politique de confidentialité complète."
+	"privacy_policy_cta_lead": "Vous voulez tous les détails ? Consultez notre politique de confidentialité complète.",
+	"teaser_org_api_title": "Automatisez le partage de secrets pour votre organisation",
+	"teaser_org_api_description": "Passez à Top Secret Service pour créer des clés API à l'échelle de l'organisation et générer des secrets de manière programmatique depuis vos propres applications.",
+	"org_api_keys_card_description": "Créez des clés API pour votre organisation. Tout propriétaire ou administrateur peut les créer et les révoquer.",
+	"org_api_keys_domain_title": "Les clés sont limitées à votre domaine",
+	"org_api_keys_domain_description": "Les clés API de l'organisation ne fonctionnent que pour les secrets créés sur {domain}. Indiquez-le via l'option host du module client — ou via l'en-tête X-Host si vous appelez l'API directement.",
+	"org_api_keys_no_domain_title": "Aucun domaine en marque blanche configuré",
+	"org_api_keys_no_domain_description": "Les clés API de l'organisation sont limitées au domaine en marque blanche de votre organisation. Configurez d'abord un domaine personnalisé — d'ici là, les clés créées ici ne pourront pas créer de secrets.",
+	"org_api_keys_no_domain_cta": "Configurer le domaine en marque blanche",
+	"org_api_keys_plan_required_title": "Mise à niveau du forfait requise",
+	"org_api_keys_plan_required_description": "Les clés API d'organisation nécessitent le forfait Top Secret Service.",
+	"org_api_keys_limit_description": "Un maximum de {amount} clés API est autorisé par organisation. Pour créer une nouvelle clé, veuillez révoquer une clé existante."
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Accordo sul Trattamento dei Dati (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Generare un Accordo sul Trattamento dei Dati (DPA) per scrt.link, pronto da firmare. Conforme al GDPR e alla FADP svizzera.",
 	"dpa_your_details": "Dati dell’azienda",
 	"dpa_field_company_name": "Ragione sociale",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Posso usare scrt.link in modo anonimo?",
 	"privacy_faq_anonymous_a": "Sì. Creare e condividere un segreto non richiede alcun account né informazioni personali. Un account è facoltativo e sblocca solo funzionalità aggiuntive.",
 	"privacy_policy_cta_title": "La versione legale completa",
-	"privacy_policy_cta_lead": "Vuoi ogni dettaglio? Leggi la nostra informativa sulla privacy completa."
+	"privacy_policy_cta_lead": "Vuoi ogni dettaglio? Leggi la nostra informativa sulla privacy completa.",
+	"teaser_org_api_title": "Automatizza la condivisione di segreti per la tua organizzazione",
+	"teaser_org_api_description": "Passa a Top Secret Service per creare chiavi API a livello di organizzazione e generare segreti in modo programmatico dalle tue applicazioni.",
+	"org_api_keys_card_description": "Crea chiavi API per la tua organizzazione. Qualsiasi proprietario o amministratore può crearle e revocarle.",
+	"org_api_keys_domain_title": "Le chiavi sono limitate al tuo dominio",
+	"org_api_keys_domain_description": "Le chiavi API dell'organizzazione funzionano solo per i segreti creati su {domain}. Impostalo come opzione host nel modulo client — o come header X-Host se chiami l'API direttamente.",
+	"org_api_keys_no_domain_title": "Nessun dominio white-label configurato",
+	"org_api_keys_no_domain_description": "Le chiavi API dell'organizzazione sono limitate al dominio white-label della tua organizzazione. Configura prima un dominio personalizzato: fino ad allora, le chiavi create qui non potranno creare segreti.",
+	"org_api_keys_no_domain_cta": "Configura dominio white-label",
+	"org_api_keys_plan_required_title": "È necessario aggiornare il piano",
+	"org_api_keys_plan_required_description": "Le chiavi API dell'organizzazione richiedono il piano Top Secret Service.",
+	"org_api_keys_limit_description": "È consentito un massimo di {amount} chiavi API per organizzazione. Per creare una nuova chiave, revoca una di quelle esistenti."
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "データ処理契約（DPA）",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "scrt.link 用のデータ処理契約（DPA）を生成し、そのまま署名できます。GDPR およびスイス FADP に準拠。",
 	"dpa_your_details": "会社情報",
 	"dpa_field_company_name": "会社の正式名称",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "scrt.link を匿名で利用できますか？",
 	"privacy_faq_anonymous_a": "はい。シークレットの作成と共有にアカウントや個人情報は不要です。アカウントは任意で、追加機能を利用できるようになるだけです。",
 	"privacy_policy_cta_title": "完全な法的バージョン",
-	"privacy_policy_cta_lead": "すべての詳細をご覧になりたいですか？完全なプライバシーポリシーをお読みください。"
+	"privacy_policy_cta_lead": "すべての詳細をご覧になりたいですか？完全なプライバシーポリシーをお読みください。",
+	"teaser_org_api_title": "組織のシークレット共有を自動化",
+	"teaser_org_api_description": "Top Secret Service にアップグレードすると、組織全体の API キーを作成し、自分のアプリケーションからプログラムでシークレットを生成できます。",
+	"org_api_keys_card_description": "組織用の API キーを作成します。オーナーと管理者であれば作成・取り消しができます。",
+	"org_api_keys_domain_title": "キーは自組織のドメインに限定されます",
+	"org_api_keys_domain_description": "組織の API キーは {domain} で作成されるシークレットにのみ使用できます。クライアントモジュールでは host オプションに指定し、API を直接呼び出す場合は X-Host ヘッダーで送信してください。",
+	"org_api_keys_no_domain_title": "ホワイトラベルドメインが未設定です",
+	"org_api_keys_no_domain_description": "組織の API キーは、組織のホワイトラベルドメインに限定されます。まずカスタムドメインを設定してください。それまでは、ここで作成したキーでシークレットを作成することはできません。",
+	"org_api_keys_no_domain_cta": "ホワイトラベルドメインを設定",
+	"org_api_keys_plan_required_title": "プランのアップグレードが必要です",
+	"org_api_keys_plan_required_description": "組織の API キーには Top Secret Service プランが必要です。",
+	"org_api_keys_limit_description": "組織あたり最大 {amount} 個の API キーが許可されています。新しいキーを作成するには、既存のキーを取り消してください。"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Verwerkersovereenkomst (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Genereer een verwerkersovereenkomst (DPA) voor scrt.link, klaar om te ondertekenen. Conform de GDPR en de Zwitserse FADP.",
 	"dpa_your_details": "Bedrijfsgegevens",
 	"dpa_field_company_name": "Juridische bedrijfsnaam",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Kan ik scrt.link anoniem gebruiken?",
 	"privacy_faq_anonymous_a": "Ja. Voor het aanmaken en delen van een geheim is geen account en geen persoonlijke informatie nodig. Een account is optioneel en ontgrendelt alleen extra functies.",
 	"privacy_policy_cta_title": "De volledige juridische versie",
-	"privacy_policy_cta_lead": "Wil je elk detail? Lees ons volledige privacybeleid."
+	"privacy_policy_cta_lead": "Wil je elk detail? Lees ons volledige privacybeleid.",
+	"teaser_org_api_title": "Automatiseer het delen van geheimen voor je organisatie",
+	"teaser_org_api_description": "Upgrade naar Top Secret Service om API-sleutels voor de hele organisatie te maken en programmatisch geheimen te genereren vanuit je eigen applicaties.",
+	"org_api_keys_card_description": "Maak API-sleutels voor je organisatie. Elke eigenaar of beheerder kan ze aanmaken en intrekken.",
+	"org_api_keys_domain_title": "Sleutels zijn beperkt tot je domein",
+	"org_api_keys_domain_description": "API-sleutels van de organisatie werken alleen voor geheimen die op {domain} worden aangemaakt. Stel dit in als host-optie in de clientmodule — of als X-Host-header bij directe API-aanroepen.",
+	"org_api_keys_no_domain_title": "Geen white-label domein geconfigureerd",
+	"org_api_keys_no_domain_description": "API-sleutels van de organisatie zijn beperkt tot het white-label domein van je organisatie. Stel eerst een eigen domein in — tot die tijd kunnen sleutels die je hier maakt geen geheimen aanmaken.",
+	"org_api_keys_no_domain_cta": "White-label domein instellen",
+	"org_api_keys_plan_required_title": "Planupgrade vereist",
+	"org_api_keys_plan_required_description": "API-sleutels voor organisaties vereisen het Top Secret Service-plan.",
+	"org_api_keys_limit_description": "Er zijn maximaal {amount} API-sleutels per organisatie toegestaan. Trek een bestaande sleutel in om een nieuwe te maken."
 }

--- a/messages/no.json
+++ b/messages/no.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Databehandleravtale (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Generer en databehandleravtale (DPA) for scrt.link, klar til signering. I samsvar med GDPR og sveitsiske FADP.",
 	"dpa_your_details": "Firmaopplysninger",
 	"dpa_field_company_name": "Juridisk firmanavn",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Kan jeg bruke scrt.link anonymt?",
 	"privacy_faq_anonymous_a": "Ja. Å opprette og dele en hemmelighet krever ingen konto og ingen personopplysninger. En konto er valgfri og låser bare opp flere funksjoner.",
 	"privacy_policy_cta_title": "Den fullstendige juridiske versjonen",
-	"privacy_policy_cta_lead": "Vil du ha hver detalj? Les hele personvernerklæringen vår."
+	"privacy_policy_cta_lead": "Vil du ha hver detalj? Les hele personvernerklæringen vår.",
+	"teaser_org_api_title": "Automatiser deling av hemmeligheter for organisasjonen din",
+	"teaser_org_api_description": "Oppgrader til Top Secret Service for å opprette API-nøkler for hele organisasjonen og generere hemmeligheter programmatisk fra dine egne applikasjoner.",
+	"org_api_keys_card_description": "Opprett API-nøkler for organisasjonen din. Alle eiere og administratorer kan opprette og tilbakekalle dem.",
+	"org_api_keys_domain_title": "Nøklene er begrenset til domenet ditt",
+	"org_api_keys_domain_description": "Organisasjonens API-nøkler fungerer bare for hemmeligheter som opprettes på {domain}. Angi det som host-alternativet i klientmodulen – eller som X-Host-header ved direkte API-kall.",
+	"org_api_keys_no_domain_title": "Ingen white-label-domene konfigurert",
+	"org_api_keys_no_domain_description": "Organisasjonens API-nøkler er begrenset til organisasjonens white-label-domene. Sett opp et eget domene først – inntil da kan ikke nøkler du oppretter her opprette hemmeligheter.",
+	"org_api_keys_no_domain_cta": "Sett opp white-label-domene",
+	"org_api_keys_plan_required_title": "Oppgradering av plan kreves",
+	"org_api_keys_plan_required_description": "API-nøkler for organisasjoner krever Top Secret Service-planen.",
+	"org_api_keys_limit_description": "Maks {amount} API-nøkler er tillatt per organisasjon. For å opprette en ny nøkkel må du tilbakekalle en eksisterende."
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Umowa powierzenia przetwarzania danych (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Wygeneruj umowę powierzenia przetwarzania danych (DPA) dla scrt.link, gotową do podpisu. Zgodną z GDPR i szwajcarską FADP.",
 	"dpa_your_details": "Dane firmy",
 	"dpa_field_company_name": "Nazwa prawna firmy",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Czy mogę korzystać ze scrt.link anonimowo?",
 	"privacy_faq_anonymous_a": "Tak. Tworzenie i udostępnianie sekretu nie wymaga konta ani żadnych danych osobowych. Konto jest opcjonalne i odblokowuje jedynie dodatkowe funkcje.",
 	"privacy_policy_cta_title": "Pełna wersja prawna",
-	"privacy_policy_cta_lead": "Chcesz poznać każdy szczegół? Przeczytaj naszą pełną politykę prywatności."
+	"privacy_policy_cta_lead": "Chcesz poznać każdy szczegół? Przeczytaj naszą pełną politykę prywatności.",
+	"teaser_org_api_title": "Zautomatyzuj udostępnianie sekretów w Twojej organizacji",
+	"teaser_org_api_description": "Przejdź na Top Secret Service, aby tworzyć klucze API dla całej organizacji i programowo generować sekrety z własnych aplikacji.",
+	"org_api_keys_card_description": "Twórz klucze API dla swojej organizacji. Każdy właściciel lub administrator może je tworzyć i cofać.",
+	"org_api_keys_domain_title": "Klucze są ograniczone do Twojej domeny",
+	"org_api_keys_domain_description": "Klucze API organizacji działają tylko dla sekretów tworzonych w domenie {domain}. Ustaw ją jako opcję host w module klienta — lub jako nagłówek X-Host przy bezpośrednim wywołaniu API.",
+	"org_api_keys_no_domain_title": "Nie skonfigurowano domeny white-label",
+	"org_api_keys_no_domain_description": "Klucze API organizacji są ograniczone do domeny white-label Twojej organizacji. Najpierw skonfiguruj własną domenę — do tego czasu klucze utworzone tutaj nie będą mogły tworzyć sekretów.",
+	"org_api_keys_no_domain_cta": "Skonfiguruj domenę white-label",
+	"org_api_keys_plan_required_title": "Wymagane ulepszenie planu",
+	"org_api_keys_plan_required_description": "Klucze API organizacji wymagają planu Top Secret Service.",
+	"org_api_keys_limit_description": "Na organizację dozwolone jest maksymalnie {amount} kluczy API. Aby utworzyć nowy klucz, cofnij istniejący."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Acordo de Tratamento de Dados (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Gerar um Acordo de Tratamento de Dados (DPA) para scrt.link, pronto para assinar. Em conformidade com o GDPR e a FADP suíça.",
 	"dpa_your_details": "Dados da empresa",
 	"dpa_field_company_name": "Nome legal da empresa",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Posso usar o scrt.link de forma anónima?",
 	"privacy_faq_anonymous_a": "Sim. Criar e partilhar um segredo não requer conta nem informações pessoais. Uma conta é opcional e apenas desbloqueia funcionalidades adicionais.",
 	"privacy_policy_cta_title": "A versão legal completa",
-	"privacy_policy_cta_lead": "Quer todos os detalhes? Leia a nossa política de privacidade completa."
+	"privacy_policy_cta_lead": "Quer todos os detalhes? Leia a nossa política de privacidade completa.",
+	"teaser_org_api_title": "Automatize o compartilhamento de segredos da sua organização",
+	"teaser_org_api_description": "Faça upgrade para Top Secret Service para criar chaves API para toda a organização e gerar segredos programaticamente a partir das suas próprias aplicações.",
+	"org_api_keys_card_description": "Crie chaves API para a sua organização. Qualquer proprietário ou administrador pode criá-las e revogá-las.",
+	"org_api_keys_domain_title": "As chaves estão restritas ao seu domínio",
+	"org_api_keys_domain_description": "As chaves API da organização só funcionam para segredos criados em {domain}. Defina-o como opção host no módulo cliente — ou como cabeçalho X-Host ao chamar a API diretamente.",
+	"org_api_keys_no_domain_title": "Nenhum domínio white-label configurado",
+	"org_api_keys_no_domain_description": "As chaves API da organização estão restritas ao domínio white-label da sua organização. Configure primeiro um domínio próprio — até lá, as chaves criadas aqui não conseguirão criar segredos.",
+	"org_api_keys_no_domain_cta": "Configurar domínio white-label",
+	"org_api_keys_plan_required_title": "É necessário atualizar o plano",
+	"org_api_keys_plan_required_description": "As chaves API de organização requerem o plano Top Secret Service.",
+	"org_api_keys_limit_description": "É permitido um máximo de {amount} chaves API por organização. Para criar uma nova chave, revogue uma existente."
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Соглашение об обработке данных (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Создание соглашения об обработке данных (DPA) для scrt.link, готового к подписанию. Соответствует GDPR и швейцарскому FADP.",
 	"dpa_your_details": "Данные компании",
 	"dpa_field_company_name": "Юридическое название компании",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Могу ли я использовать scrt.link анонимно?",
 	"privacy_faq_anonymous_a": "Да. Создание секрета и обмен им не требуют аккаунта и персональной информации. Аккаунт необязателен и лишь открывает доступ к дополнительным возможностям.",
 	"privacy_policy_cta_title": "Полная юридическая версия",
-	"privacy_policy_cta_lead": "Хотите все подробности? Прочитайте нашу полную политику приватности."
+	"privacy_policy_cta_lead": "Хотите все подробности? Прочитайте нашу полную политику приватности.",
+	"teaser_org_api_title": "Автоматизируйте обмен секретами в вашей организации",
+	"teaser_org_api_description": "Перейдите на Top Secret Service, чтобы создавать API-ключи для всей организации и генерировать секреты программно из ваших приложений.",
+	"org_api_keys_card_description": "Создавайте API-ключи для вашей организации. Любой владелец или администратор может создавать и отзывать их.",
+	"org_api_keys_domain_title": "Ключи ограничены вашим доменом",
+	"org_api_keys_domain_description": "API-ключи организации работают только для секретов, создаваемых на {domain}. Укажите его в параметре host клиентского модуля — или в заголовке X-Host при прямом обращении к API.",
+	"org_api_keys_no_domain_title": "White-label домен не настроен",
+	"org_api_keys_no_domain_description": "API-ключи организации ограничены white-label доменом вашей организации. Сначала настройте собственный домен — до этого созданные здесь ключи не смогут создавать секреты.",
+	"org_api_keys_no_domain_cta": "Настроить white-label домен",
+	"org_api_keys_plan_required_title": "Требуется обновление тарифа",
+	"org_api_keys_plan_required_description": "Для API-ключей организации требуется тариф Top Secret Service.",
+	"org_api_keys_limit_description": "Максимум {amount} API-ключей разрешено на организацию. Чтобы создать новый ключ, отзовите один из существующих."
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "Personuppgiftsbiträdesavtal (DPA)",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "Skapa ett personuppgiftsbiträdesavtal (DPA) för scrt.link, redo att signera. Följer GDPR och schweiziska FADP.",
 	"dpa_your_details": "Företagsuppgifter",
 	"dpa_field_company_name": "Juridiskt företagsnamn",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "Kan jag använda scrt.link anonymt?",
 	"privacy_faq_anonymous_a": "Ja. Att skapa och dela en hemlighet kräver inget konto och ingen personlig information. Ett konto är valfritt och låser bara upp ytterligare funktioner.",
 	"privacy_policy_cta_title": "Den fullständiga juridiska versionen",
-	"privacy_policy_cta_lead": "Vill du ha varje detalj? Läs vår kompletta integritetspolicy."
+	"privacy_policy_cta_lead": "Vill du ha varje detalj? Läs vår kompletta integritetspolicy.",
+	"teaser_org_api_title": "Automatisera hemlighetsdelning för din organisation",
+	"teaser_org_api_description": "Uppgradera till Top Secret Service för att skapa API-nycklar för hela organisationen och generera hemligheter programmatiskt från dina egna applikationer.",
+	"org_api_keys_card_description": "Skapa API-nycklar för din organisation. Alla ägare och administratörer kan skapa och återkalla dem.",
+	"org_api_keys_domain_title": "Nycklarna är begränsade till din domän",
+	"org_api_keys_domain_description": "Organisationens API-nycklar fungerar bara för hemligheter som skapas på {domain}. Ange den som host-alternativ i klientmodulen – eller som X-Host-header vid direkta API-anrop.",
+	"org_api_keys_no_domain_title": "Ingen white-label-domän konfigurerad",
+	"org_api_keys_no_domain_description": "Organisationens API-nycklar är begränsade till organisationens white-label-domän. Konfigurera en egen domän först – fram till dess kan nycklar du skapar här inte skapa några hemligheter.",
+	"org_api_keys_no_domain_cta": "Konfigurera white-label-domän",
+	"org_api_keys_plan_required_title": "Uppgradering av plan krävs",
+	"org_api_keys_plan_required_description": "API-nycklar för organisationer kräver planen Top Secret Service.",
+	"org_api_keys_limit_description": "Högst {amount} API-nycklar tillåts per organisation. För att skapa en ny nyckel, återkalla en befintlig."
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
-	"dpa_title_short": "DPA",
 	"dpa_title": "数据处理协议（DPA）",
+	"dpa_title_short": "DPA",
 	"dpa_lead": "为 scrt.link 生成可直接签署的数据处理协议（DPA）。符合 GDPR 和瑞士 FADP。",
 	"dpa_your_details": "公司信息",
 	"dpa_field_company_name": "公司法定名称",
@@ -1088,5 +1088,16 @@
 	"privacy_faq_anonymous_q": "我可以匿名使用 scrt.link 吗？",
 	"privacy_faq_anonymous_a": "可以。创建和分享秘密无需账户，也无需任何个人信息。账户是可选的，只会解锁额外功能。",
 	"privacy_policy_cta_title": "完整的法律版本",
-	"privacy_policy_cta_lead": "想了解每个细节？请阅读我们完整的隐私政策。"
+	"privacy_policy_cta_lead": "想了解每个细节？请阅读我们完整的隐私政策。",
+	"teaser_org_api_title": "为您的组织自动化私密分享",
+	"teaser_org_api_description": "升级至 Top Secret Service，即可创建组织级 API 密钥，并从您自己的应用程序中以编程方式生成秘密。",
+	"org_api_keys_card_description": "为您的组织创建 API 密钥。任何所有者或管理员都可以创建和撤销这些密钥。",
+	"org_api_keys_domain_title": "密钥仅限于您的域名",
+	"org_api_keys_domain_description": "组织 API 密钥仅适用于在 {domain} 上创建的秘密。请在客户端模块中通过 host 选项设置该域名，或在直接调用 API 时使用 X-Host 标头。",
+	"org_api_keys_no_domain_title": "尚未配置白标域名",
+	"org_api_keys_no_domain_description": "组织 API 密钥仅限于您组织的白标域名。请先设置自定义域名——在此之前，这里创建的密钥无法创建秘密。",
+	"org_api_keys_no_domain_cta": "设置白标域名",
+	"org_api_keys_plan_required_title": "需要升级方案",
+	"org_api_keys_plan_required_description": "组织 API 密钥需要 Top Secret Service 方案。",
+	"org_api_keys_limit_description": "每个组织最多允许 {amount} 个 API 密钥。如需创建新密钥，请先撤销已有密钥。"
 }

--- a/src/lib/components/blocks/api-keys-card.svelte
+++ b/src/lib/components/blocks/api-keys-card.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+	import { Trash } from '@lucide/svelte';
+
+	import { enhance } from '$app/forms';
+	import { buttonVariants } from '$lib/components/ui/button';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Card from '$lib/components/ui/card';
+	import CopyButton from '$lib/components/ui/copy-button';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import Markdown from '$lib/components/ui/markdown';
+	import { m } from '$lib/paraglide/messages.js';
+
+	type ApiKeyItem = { id: string; key: string; description: string | null };
+
+	type Props = {
+		apiKeys: ApiKeyItem[];
+		// When set, revoking targets the organization's keys instead of the user's own.
+		organizationId?: string;
+		class?: string;
+	};
+
+	let { apiKeys, organizationId, class: className }: Props = $props();
+
+	let isConfirmationDialogOpen = $state(false);
+	let selectedKeyForDeletion = $state<ApiKeyItem | null>(null);
+</script>
+
+<Card class={className} title={m.lost_slimy_pelican_achieve()}>
+	{#if apiKeys.length}
+		{#each apiKeys as item (item.id)}
+			<div
+				class="bg-background/60 border-border mb-3 grid grid-cols-[100px_1fr] gap-2 overflow-hidden border p-2 px-4 sm:grid-cols-[100px_1fr_min-content_min-content]"
+			>
+				<div
+					class="max-w-full items-center justify-center self-center justify-self-start truncate text-sm"
+				>
+					{item.description}
+				</div>
+				<Input type="text" value={item.key} disabled />
+				<div class="col-span-2 flex justify-end">
+					<CopyButton variant="ghost" text={item.key}></CopyButton>
+
+					<Button
+						variant="ghost"
+						class="text-destructive"
+						onclick={() => {
+							selectedKeyForDeletion = item;
+							isConfirmationDialogOpen = true;
+						}}
+					>
+						<Trash class="me-2 h-4 w-4" />{m.tense_spicy_jannes_hug()}
+					</Button>
+				</div>
+			</div>
+		{/each}
+	{:else}
+		<p class="text-muted-foreground text-sm">
+			{m.dry_tame_warthog_hurl()}
+		</p>
+	{/if}
+</Card>
+
+<Dialog.Root bind:open={isConfirmationDialogOpen}>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>{m.soft_aloof_barbel_splash()}</Dialog.Title>
+			<Dialog.Description>
+				<Markdown
+					format
+					markdown={m.firm_zippy_warthog_chop({
+						description: selectedKeyForDeletion?.description || ''
+					})}
+				/>
+			</Dialog.Description>
+		</Dialog.Header>
+		<Dialog.Footer>
+			<Dialog.Close class={buttonVariants({ variant: 'outline' })}>
+				{m.big_due_warthog_rest()}
+			</Dialog.Close>
+			<form
+				method="post"
+				use:enhance
+				action="?/revokeAPIToken"
+				onsubmit={() => (isConfirmationDialogOpen = false)}
+			>
+				<input type="hidden" name="keyId" value={selectedKeyForDeletion?.id} />
+				{#if organizationId}
+					<input type="hidden" name="organizationId" value={organizationId} />
+				{/if}
+				<Button type="submit" variant="destructive" class="max-sm:mb-2">
+					{m.tense_spicy_jannes_hug()}
+				</Button>
+			</form>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/forms/api-token-form.svelte
+++ b/src/lib/components/forms/api-token-form.svelte
@@ -4,24 +4,18 @@
 
 	import Text from '$lib/components/forms/form-fields/text.svelte';
 	import * as Form from '$lib/components/ui/form';
-	import { TierOptions } from '$lib/data/enums';
-	import { getUserPlanLimits } from '$lib/data/plans';
 	import { m } from '$lib/paraglide/messages.js';
 	import { apiKeyFormSchema, type ApiTokenFormSchema } from '$lib/validators/formSchemas';
 
 	import FormWrapper from './form-wrapper.svelte';
 
+	// Callers are responsible for gating on plan access; the organization this key belongs to
+	// (if any) travels with the form data, preloaded server-side by apiKeyFormValidator.
 	type Props = {
 		form: SuperValidated<Infer<ApiTokenFormSchema>>;
-		user: App.Locals['user'];
-		effectiveTier?: TierOptions;
 	};
 
-	let { user, form: formProp, effectiveTier }: Props = $props();
-
-	const planLimits = $derived(
-		getUserPlanLimits(effectiveTier ?? user?.subscriptionTier ?? TierOptions.CONFIDENTIAL)
-	);
+	let { form: formProp }: Props = $props();
 
 	const form = superForm(formProp, {
 		validators: zod4Client(apiKeyFormSchema()),
@@ -54,7 +48,6 @@
 					bind:value={$formData.description}
 					{...$constraints.description}
 					description={m.fluffy_even_fox_greet()}
-					disabled={!planLimits.apiAccess}
 				/>
 			</Form.Field>
 			<Form.Button delayed={$delayed} class="my-2">{m.actual_keen_rooster_find()}</Form.Button>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,4 +20,5 @@ export const getBaseUrl = () => {
 
 export const FILE_RETENTION_PERIOD_IN_DAYS = 30;
 export const MAX_API_KEYS_PER_USER = 5;
+export const MAX_API_KEYS_PER_ORGANIZATION = 5;
 export const MAX_ORGANIZATIONS_PER_USER = 1;

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -285,7 +285,14 @@ export const apiKey = pgTable('api_key', {
 	description: text('description'),
 	createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 	revoked: boolean('revoked').default(false),
-	userId: uuid('user_id').references(() => user.id, { onDelete: 'cascade' })
+	// The user who created the key. Set for both personal and organization keys —
+	// secrets created via an organization key are attributed to the creator.
+	userId: uuid('user_id').references(() => user.id, { onDelete: 'cascade' }),
+	// Set only for organization keys. Such keys are restricted to the
+	// organization's white-label domain.
+	organizationId: uuid('organization_id').references(() => organization.id, {
+		onDelete: 'cascade'
+	})
 });
 
 export const stripeWebhookEventStatus = pgEnum('stripe_webhook_event_status', [

--- a/src/lib/server/form/actions.ts
+++ b/src/lib/server/form/actions.ts
@@ -1,11 +1,15 @@
 import { type Action, error, fail, isRedirect } from '@sveltejs/kit';
 import { timingSafeEqual } from 'crypto';
-import { and, desc, eq } from 'drizzle-orm';
+import { and, desc, eq, isNull } from 'drizzle-orm';
 import type { PostgresError } from 'postgres';
 import { message, setError, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
 
-import { MAX_API_KEYS_PER_USER, MAX_ORGANIZATIONS_PER_USER } from '$lib/constants';
+import {
+	MAX_API_KEYS_PER_ORGANIZATION,
+	MAX_API_KEYS_PER_USER,
+	MAX_ORGANIZATIONS_PER_USER
+} from '$lib/constants';
 import { generateBase64Token, scryptHash, verifyPassword } from '$lib/crypto';
 import { InviteStatus, MembershipRole } from '$lib/data/enums';
 import { getUserPlanLimits } from '$lib/data/plans';
@@ -75,6 +79,8 @@ import {
 	deleteEmailVerificationRequests
 } from '../email-verification';
 import {
+	getActiveApiKeysByOrgId,
+	getOrganizationById,
 	getOrganizationsByUserId,
 	inviteUserToOrganization,
 	isUserOrgOwnerOrAdmin,
@@ -1473,8 +1479,6 @@ export const createAPIToken: Action = async (event) => {
 
 	const user = event.locals.user;
 
-	const { description } = form.data;
-
 	if (!form.valid) {
 		return fail(400, { form });
 	}
@@ -1483,25 +1487,62 @@ export const createAPIToken: Action = async (event) => {
 		return redirectLocalized(307, '/signup');
 	}
 
-	const activeApiKeys = await getActiveApiKeys(user.id);
+	const { description, organizationId } = form.data;
 
-	// Too many API keys
-	if (activeApiKeys.length >= MAX_API_KEYS_PER_USER) {
-		return message(
-			form,
-			{
-				status: 'error',
-				title: m.neat_less_jurgen_trip(),
-				description: m.such_safe_leopard_lend({ amount: MAX_API_KEYS_PER_USER })
-			},
-			{
-				status: 401
-			}
-		);
+	if (organizationId) {
+		if (!(await isUserOrgOwnerOrAdmin(user.id, organizationId))) {
+			return fail(403, { form });
+		}
+
+		const org = await getOrganizationById({ organizationId });
+
+		if (!getUserPlanLimits(org?.subscriptionTier).apiAccess) {
+			return message(
+				form,
+				{
+					status: 'error',
+					title: m.org_api_keys_plan_required_title(),
+					description: m.org_api_keys_plan_required_description()
+				},
+				{ status: 403 }
+			);
+		}
+
+		const activeOrgApiKeys = await getActiveApiKeysByOrgId(organizationId);
+
+		if (activeOrgApiKeys.length >= MAX_API_KEYS_PER_ORGANIZATION) {
+			return message(
+				form,
+				{
+					status: 'error',
+					title: m.neat_less_jurgen_trip(),
+					description: m.org_api_keys_limit_description({ amount: MAX_API_KEYS_PER_ORGANIZATION })
+				},
+				{ status: 403 }
+			);
+		}
+	} else {
+		const activeApiKeys = await getActiveApiKeys(user.id);
+
+		// Too many API keys
+		if (activeApiKeys.length >= MAX_API_KEYS_PER_USER) {
+			return message(
+				form,
+				{
+					status: 'error',
+					title: m.neat_less_jurgen_trip(),
+					description: m.such_safe_leopard_lend({ amount: MAX_API_KEYS_PER_USER })
+				},
+				{
+					status: 401
+				}
+			);
+		}
 	}
 
 	await db.insert(apiKey).values({
 		userId: user.id,
+		organizationId: organizationId || null,
 		description: description || m.real_fluffy_clownfish_fetch(),
 		key: `ak_${generateBase64Token()}`
 	});
@@ -1516,17 +1557,29 @@ export const revokeAPIToken: Action = async (event) => {
 	const apiKeyForm = await superValidate(event.request, zod4(apiKeyFormSchema()), {
 		id: 'api-token-form'
 	});
-	const { keyId } = apiKeyForm.data;
+	const { keyId, organizationId } = apiKeyForm.data;
 	const user = event.locals.user;
 
 	if (!user || !keyId) {
 		return fail(401);
 	}
 
-	await db
-		.update(apiKey)
-		.set({ revoked: true })
-		.where(and(eq(apiKey.id, keyId), eq(apiKey.userId, user.id)));
+	if (organizationId) {
+		// Any owner or admin may revoke an organization key, regardless of who created it.
+		if (!(await isUserOrgOwnerOrAdmin(user.id, organizationId))) {
+			return fail(403, { form: apiKeyForm });
+		}
+
+		await db
+			.update(apiKey)
+			.set({ revoked: true })
+			.where(and(eq(apiKey.id, keyId), eq(apiKey.organizationId, organizationId)));
+	} else {
+		await db
+			.update(apiKey)
+			.set({ revoked: true })
+			.where(and(eq(apiKey.id, keyId), eq(apiKey.userId, user.id), isNull(apiKey.organizationId)));
+	}
 
 	return message(apiKeyForm, {
 		status: 'success',

--- a/src/lib/server/form/validators.ts
+++ b/src/lib/server/form/validators.ts
@@ -83,9 +83,10 @@ export const userFormValidator = async (user: App.Locals['user']) => {
 	);
 };
 
-export const apiKeyFormValidator = async () =>
-	await superValidate(zod4(apiKeyFormSchema()), {
-		id: 'api-token-form'
+export const apiKeyFormValidator = async (organizationId?: string) =>
+	await superValidate({ organizationId }, zod4(apiKeyFormSchema()), {
+		id: 'api-token-form',
+		errors: false
 	});
 
 // Secret Requests

--- a/src/lib/server/organization.ts
+++ b/src/lib/server/organization.ts
@@ -6,7 +6,15 @@ import { InviteStatus, MembershipRole, TierOptions } from '$lib/data/enums';
 import { DAY } from '$lib/data/units';
 
 import { db } from './db';
-import { invite, membership, type Organization, organization, type User, user } from './db/schema';
+import {
+	apiKey,
+	invite,
+	membership,
+	type Organization,
+	organization,
+	type User,
+	user
+} from './db/schema';
 import stripeInstance, { getActiveSubscription } from './stripe';
 import { sendOrganisationInvitationEmail } from './transactional-email';
 
@@ -84,6 +92,12 @@ export const isMemberOfOrganization = async (
 
 	return !!result;
 };
+
+export const getActiveApiKeysByOrgId = async (organizationId: Organization['id']) =>
+	await db
+		.select()
+		.from(apiKey)
+		.where(and(eq(apiKey.organizationId, organizationId), eq(apiKey.revoked, false)));
 
 export const isUserOrgOwnerOrAdmin = async (
 	userId: string,

--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 
 import { verifyPassword } from '$lib/crypto';
 import type { PartialExcept } from '$lib/typescript-helpers';
@@ -164,4 +164,6 @@ export const getActiveApiKeys = async (userId: User['id']) =>
 	await db
 		.select()
 		.from(apiKey)
-		.where(and(eq(apiKey.userId, userId), eq(apiKey.revoked, false)));
+		.where(
+			and(eq(apiKey.userId, userId), eq(apiKey.revoked, false), isNull(apiKey.organizationId))
+		);

--- a/src/lib/validators/formSchemas.ts
+++ b/src/lib/validators/formSchemas.ts
@@ -311,7 +311,9 @@ export const contactFormSchema = () =>
 export const apiKeyFormSchema = () =>
 	z.object({
 		keyId: z.string().optional(),
-		description: z.string().max(50).optional()
+		description: z.string().max(50).optional(),
+		// When set, the key belongs to the organization rather than the user.
+		organizationId: z.string().optional()
 	});
 
 export const encryptionSetupFormSchema = () =>

--- a/src/routes/(app)/(default)/account/api/+page.svelte
+++ b/src/routes/(app)/(default)/account/api/+page.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
-	import { Code, Trash } from '@lucide/svelte';
+	import { Code } from '@lucide/svelte';
 
-	import { enhance } from '$app/forms';
+	import ApiKeysCard from '$lib/components/blocks/api-keys-card.svelte';
 	import UpgradeNotice from '$lib/components/blocks/upgrade-notice.svelte';
 	import ApiTokenForm from '$lib/components/forms/api-token-form.svelte';
-	import { buttonVariants } from '$lib/components/ui/button';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import Card from '$lib/components/ui/card';
-	import CopyButton from '$lib/components/ui/copy-button';
-	import * as Dialog from '$lib/components/ui/dialog';
-	import Input from '$lib/components/ui/input/input.svelte';
-	import Markdown from '$lib/components/ui/markdown';
 	import { getUserPlanLimits } from '$lib/data/plans';
 	import { m } from '$lib/paraglide/messages.js';
 	import { localizeHref } from '$lib/paraglide/runtime';
@@ -20,9 +15,6 @@
 	let { data }: { data: PageData } = $props();
 
 	let planLimits = $derived(getUserPlanLimits(data.effectiveTier));
-
-	let isConfirmationDialogOpen = $state(false);
-	let selectedKeyForDeletion = $state<{ id: string; description: string | null } | null>(null);
 </script>
 
 {#if planLimits.apiAccess}
@@ -31,78 +23,13 @@
 		title={m.actual_keen_rooster_find()}
 		description={m.patchy_swift_fish_cuddle()}
 	>
-		<ApiTokenForm user={data.user} effectiveTier={data.effectiveTier} form={data.apiKeyForm} />
+		<ApiTokenForm form={data.apiKeyForm} />
 	</Card>
 
-	<Card class="mb-6" title={m.lost_slimy_pelican_achieve()}>
-		{#if data.apiKeys.length}
-			{#each data.apiKeys as item, i (i)}
-				<div
-					class="bg-background/60 border-border mb-3 grid grid-cols-[100px_1fr] gap-2 overflow-hidden border p-2 px-4 sm:grid-cols-[100px_1fr_min-content_min-content]"
-				>
-					<div
-						class="max-w-full items-center justify-center self-center justify-self-start truncate text-sm"
-					>
-						{item.description}
-					</div>
-					<Input type="text" value={item.key} disabled />
-					<div class="col-span-2 flex justify-end">
-						<CopyButton variant="ghost" text={item.key}></CopyButton>
-
-						<Button
-							variant="ghost"
-							class="text-destructive"
-							onclick={() => {
-								selectedKeyForDeletion = item;
-								isConfirmationDialogOpen = true;
-							}}
-						>
-							<Trash class="me-2 h-4 w-4" />{m.tense_spicy_jannes_hug()}
-						</Button>
-					</div>
-				</div>
-			{/each}
-		{:else}
-			<p class="text-muted-foreground text-sm">
-				{m.dry_tame_warthog_hurl()}
-			</p>
-		{/if}
-	</Card>
+	<ApiKeysCard class="mb-6" apiKeys={data.apiKeys} />
 {:else}
 	<UpgradeNotice tier={data.effectiveTier} class="mb-6" />
 {/if}
-
-<Dialog.Root bind:open={isConfirmationDialogOpen}>
-	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>{m.soft_aloof_barbel_splash()}</Dialog.Title>
-			<Dialog.Description>
-				<Markdown
-					format
-					markdown={m.firm_zippy_warthog_chop({
-						description: selectedKeyForDeletion?.description || ''
-					})}
-				/>
-			</Dialog.Description>
-		</Dialog.Header>
-		<Dialog.Footer>
-			<Dialog.Close class={buttonVariants({ variant: 'outline' })}>
-				{m.big_due_warthog_rest()}
-			</Dialog.Close>
-			<form
-				method="post"
-				use:enhance
-				action="?/revokeAPIToken"
-				onsubmit={() => (isConfirmationDialogOpen = false)}
-			>
-				<input type="hidden" name="keyId" value={selectedKeyForDeletion?.id} />
-				<Button type="submit" variant="destructive" class="max-sm:mb-2">
-					{m.tense_spicy_jannes_hug()}
-				</Button>
-			</form>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
 
 <Button variant="outline" href={localizeHref('/api-documentation')}>
 	<Code class="me-2 h-4 w-4" />

--- a/src/routes/(app)/(default)/account/org/[orgId]/+layout.svelte
+++ b/src/routes/(app)/(default)/account/org/[orgId]/+layout.svelte
@@ -62,11 +62,12 @@
 		exact ? currentPath === href : currentPath.startsWith(href);
 </script>
 
-<div class="mb-4 flex gap-1">
+<!-- Scrolls horizontally rather than widening the page: the tabs don't all fit on a phone. -->
+<div class="mb-4 flex gap-1 overflow-x-auto">
 	{#each subNavItems as item (item.href)}
 		<a
 			href={item.href}
-			class="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors
+			class="flex shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm whitespace-nowrap transition-colors
 				{isActive(item.href, item.exact)
 				? 'bg-muted font-medium'
 				: 'text-muted-foreground hover:text-foreground hover:bg-muted/50'}"

--- a/src/routes/(app)/(default)/account/org/[orgId]/+layout.svelte
+++ b/src/routes/(app)/(default)/account/org/[orgId]/+layout.svelte
@@ -2,6 +2,7 @@
 	import Activity from '@lucide/svelte/icons/activity';
 	import CreditCard from '@lucide/svelte/icons/credit-card';
 	import Globe from '@lucide/svelte/icons/globe';
+	import KeyRound from '@lucide/svelte/icons/key-round';
 	import Users from '@lucide/svelte/icons/users';
 	import type { Snippet } from 'svelte';
 
@@ -29,6 +30,12 @@
 						href: localizeHref(`/account/org/${orgId}/white-label`),
 						label: m.bold_slim_ram_roam(),
 						icon: Globe,
+						exact: false
+					},
+					{
+						href: localizeHref(`/account/org/${orgId}/api`),
+						label: m.super_funny_jackal_pause(),
+						icon: KeyRound,
 						exact: false
 					}
 				]

--- a/src/routes/(app)/(default)/account/org/[orgId]/api/+page.server.ts
+++ b/src/routes/(app)/(default)/account/org/[orgId]/api/+page.server.ts
@@ -1,0 +1,37 @@
+import { error } from '@sveltejs/kit';
+
+import { getUserPlanLimits } from '$lib/data/plans';
+import { redirectLocalized } from '$lib/i18n';
+import { m } from '$lib/paraglide/messages.js';
+import { createAPIToken, revokeAPIToken } from '$lib/server/form/actions';
+import { apiKeyFormValidator } from '$lib/server/form/validators';
+import { getActiveApiKeysByOrgId } from '$lib/server/organization';
+import { getWhiteLabelSiteByOrgId } from '$lib/server/whiteLabelSite';
+
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals, parent }) => {
+	const user = locals.user;
+	if (!user) return redirectLocalized(307, '/signup');
+
+	const { org, isOrgOwner, isOrgAdmin } = await parent();
+	if (!isOrgOwner && !isOrgAdmin)
+		return error(403, 'Only org owners and admins can manage API keys.');
+
+	const whiteLabel = await getWhiteLabelSiteByOrgId(org.id);
+
+	return {
+		user,
+		apiKeys: await getActiveApiKeysByOrgId(org.id),
+		apiKeyForm: await apiKeyFormValidator(org.id),
+		// Organization keys are gated on the organization's own plan, not the member's.
+		hasApiAccess: getUserPlanLimits(org.subscriptionTier).apiAccess,
+		whiteLabelDomain: whiteLabel?.customDomain ?? null,
+		pageTitle: m.super_funny_jackal_pause()
+	};
+};
+
+export const actions: Actions = {
+	createAPIToken,
+	revokeAPIToken
+};

--- a/src/routes/(app)/(default)/account/org/[orgId]/api/+page.svelte
+++ b/src/routes/(app)/(default)/account/org/[orgId]/api/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { Code, SparklesIcon } from '@lucide/svelte';
+
+	import ApiKeysCard from '$lib/components/blocks/api-keys-card.svelte';
+	import TeaserCard from '$lib/components/blocks/teaser-card.svelte';
+	import ApiTokenForm from '$lib/components/forms/api-token-form.svelte';
+	import Alert from '$lib/components/ui/alert/alert.svelte';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Card from '$lib/components/ui/card';
+	import Link from '$lib/components/ui/link';
+	import { m } from '$lib/paraglide/messages.js';
+	import { localizeHref } from '$lib/paraglide/runtime';
+
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+</script>
+
+{#if !data.hasApiAccess}
+	<TeaserCard title={m.teaser_org_api_title()} description={m.teaser_org_api_description()}>
+		{#snippet cta()}
+			<Button href={localizeHref('/pricing') + '?tab=business'}>
+				<SparklesIcon class="me-2 h-5 w-5" />
+				{m.teaser_white_label_cta()}
+			</Button>
+		{/snippet}
+	</TeaserCard>
+{:else}
+	{#if data.whiteLabelDomain}
+		<Alert variant="info" class="mb-6" title={m.org_api_keys_domain_title()}>
+			<p>{m.org_api_keys_domain_description({ domain: data.whiteLabelDomain })}</p>
+		</Alert>
+	{:else}
+		<Alert variant="destructive" class="mb-6" title={m.org_api_keys_no_domain_title()}>
+			<p>{m.org_api_keys_no_domain_description()}</p>
+			<Link href={localizeHref(`/account/org/${data.org.id}/white-label`)}>
+				{m.org_api_keys_no_domain_cta()}
+			</Link>
+		</Alert>
+	{/if}
+
+	<Card
+		class="mb-6"
+		title={m.actual_keen_rooster_find()}
+		description={m.org_api_keys_card_description()}
+	>
+		<ApiTokenForm form={data.apiKeyForm} />
+	</Card>
+
+	<ApiKeysCard class="mb-6" apiKeys={data.apiKeys} organizationId={data.org.id} />
+
+	<Button variant="outline" href={localizeHref('/api-documentation')}>
+		<Code class="me-2 h-4 w-4" />
+		{m.deft_bright_insect_attend()}
+	</Button>
+{/if}

--- a/src/routes/api/v1/secrets/+server.ts
+++ b/src/routes/api/v1/secrets/+server.ts
@@ -1,6 +1,6 @@
 import { sha256Hash } from '@scrt-link/core';
 import { json, type RequestHandler } from '@sveltejs/kit';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 import { isOriginalHostname } from '$lib/app-routing';
 import { TierOptions } from '$lib/data/enums';
@@ -8,7 +8,11 @@ import { getUserPlanLimits } from '$lib/data/plans';
 import { db } from '$lib/server/db';
 import { apiKey } from '$lib/server/db/schema';
 import { user } from '$lib/server/db/schema';
-import { getEffectiveTierForUser, isMemberOfOrganization } from '$lib/server/organization';
+import {
+	getEffectiveTierForUser,
+	getOrganizationById,
+	isMemberOfOrganization
+} from '$lib/server/organization';
 import { saveSecret } from '$lib/server/secrets';
 import { getWhiteLabelSiteByHost } from '$lib/server/whiteLabelSite';
 import { secretFormSchema } from '$lib/validators/formSchemas';
@@ -48,7 +52,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		.select()
 		.from(apiKey)
 		.leftJoin(user, eq(user.id, apiKey.userId))
-		.where(eq(apiKey.key, token));
+		.where(and(eq(apiKey.key, token), eq(apiKey.revoked, false)));
 
 	if (!userWithApiKey || !userWithApiKey.api_key) {
 		return jsonWithCors({ error: 'Invalid API key.' }, { status: 403 });
@@ -56,9 +60,19 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	const userId = userWithApiKey.user?.id;
 	const userTier = userWithApiKey.user?.subscriptionTier ?? undefined;
-	const effectiveTier = userId
-		? await getEffectiveTierForUser(userId, userTier ?? TierOptions.CONFIDENTIAL)
-		: userTier;
+	const keyOrganizationId = userWithApiKey.api_key.organizationId;
+
+	// Organization keys derive their limits from the organization's own plan, so the key keeps
+	// working as configured even if the member who created it changes plan or leaves the org.
+	let effectiveTier: TierOptions | undefined;
+	if (keyOrganizationId) {
+		const org = await getOrganizationById({ organizationId: keyOrganizationId });
+		effectiveTier = org?.subscriptionTier ?? undefined;
+	} else {
+		effectiveTier = userId
+			? await getEffectiveTierForUser(userId, userTier ?? TierOptions.CONFIDENTIAL)
+			: userTier;
+	}
 
 	const planLimits = getUserPlanLimits(effectiveTier);
 
@@ -92,8 +106,37 @@ export const POST: RequestHandler = async ({ request }) => {
 	}
 
 	let whiteLabelSiteId;
-	if (host && !isOriginalHostname(host)) {
+	if (keyOrganizationId) {
+		// Organization keys are usable only on the organization's own white-label domain.
+		if (!host || isOriginalHostname(host)) {
+			return jsonWithCors(
+				{
+					error: `Organization API keys require the X-Host header to be set to the organization's white-label domain.`
+				},
+				{ status: 400 }
+			);
+		}
+
 		const whiteLabelSiteResult = await getWhiteLabelSiteByHost(host);
+
+		if (!whiteLabelSiteResult || whiteLabelSiteResult.organizationId !== keyOrganizationId) {
+			return jsonWithCors(
+				{ error: `Not allowed to create secret for host ${host}` },
+				{ status: 400 }
+			);
+		}
+
+		whiteLabelSiteId = whiteLabelSiteResult.id;
+	} else if (host && !isOriginalHostname(host)) {
+		const whiteLabelSiteResult = await getWhiteLabelSiteByHost(host);
+
+		if (!whiteLabelSiteResult) {
+			return jsonWithCors(
+				{ error: `Not allowed to create secret for host ${host}` },
+				{ status: 400 }
+			);
+		}
+
 		whiteLabelSiteId = whiteLabelSiteResult.id;
 
 		const organizationId = whiteLabelSiteResult?.organizationId;


### PR DESCRIPTION
Owners and admins of an organization can now create and revoke API keys on the org level, from a new **API Keys** tab (sits next to White-label, same owner/admin gate).

## How org keys differ from personal keys

- **Plan gate**: resolved from the *organization's* tier, not the member's. `Top Secret Service` is the only org plan with `apiAccess`, so `Secret Service` orgs see an upgrade teaser.
- **Domain restriction**: a request must send `X-Host` matching a white-label site owned by that org. No `X-Host`, the original hostname, or another org's domain are all rejected. With the npm client this is the `host` option — note org keys will not work with the client's default `host` (`scrt.link`), which is intentional.
- **Limits come from the org**, so a key keeps working as configured if the creator downgrades or leaves.
- **Attribution**: `userId` still holds the creator, so secrets made via an org key stay attributed to a person. Personal key queries filter on a null `organizationId` so org keys don't leak onto the user's own API page.

Max 5 keys per org. Any owner/admin can revoke any org key, not just their own.

## Drive-by fixes

Two pre-existing bugs in `api/v1/secrets` that this work touched:

- **Revoked keys kept working** until the nightly cron deleted the row — the lookup never filtered `revoked`.
- An **unknown `X-Host` threw** on `.id` of `undefined` instead of returning a 400.

## Schema

Adds `api_key.organization_id` (nullable FK → `organization`, `on delete cascade`). Needs `db:push` / a migration on deploy.

## Verification

Exercised against a real org key on a Top Secret Service org with a white-label domain:

| Case | Result |
|---|---|
| Org key + correct org domain | 200, secret created on the org's site |
| Org key, no `X-Host` | 400 |
| Org key + `X-Host: localhost` | 400 |
| Org key + another org's domain | 400 |
| Revoked org key | 403 (was: created a secret) |
| Bogus key / bad checksum | 403 / 400 |
| Org key on personal API page | absent |

Also drove the UI: create → key listed → revoke → `revoked = true`, with `organizationId` correctly flowing through both actions. Test data cleaned up.

## Known limitation

Orgs whose white-label site predates the `organizationId` FK (site linked to a user, not the org) can't use org keys — the endpoint requires the site to be org-owned, and loosening that would defeat the restriction. The white-label page has a legacy fallback for these; a one-off backfill of `white_label_site.organization_id` is the fix rather than weakening the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)