### PR TITLE
feat(onboarding): skip welcome wizard for invited members

### DIFF
--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -83,8 +83,11 @@ export const createOrUpdateUser = async ({
 	emailVerified,
 	googleId,
 	name,
-	picture
-}: PartialExcept<User, 'email'>) => {
+	picture,
+	// Whether a brand-new account should see the welcome wizard. Invited members
+	// skip it (they're onboarded into an existing organization instead).
+	showWelcomeWizard = true
+}: PartialExcept<User, 'email'> & { showWelcomeWizard?: boolean }) => {
 	// Determine newness before the upsert — afterwards the row always exists.
 	const isNewUser = !(await checkIfUserExists(email));
 
@@ -105,9 +108,10 @@ export const createOrUpdateUser = async ({
 			googleId: googleId ?? null,
 			name: name ?? null,
 			picture: picture ?? null,
-			// Only new accounts get the welcome wizard. On conflict we use `updateSet`
+			// Only new accounts get the welcome wizard (and invited members opt out
+			// via `showWelcomeWizard: false`). On conflict we use `updateSet`
 			// (which omits preferences), so existing users' preferences are untouched.
-			preferences: { showWelcomeWizard: true }
+			preferences: { showWelcomeWizard }
 		})
 		.onConflictDoUpdate({
 			target: userSchema.email,

--- a/src/routes/(app)/(minimal)/invite/[token]/+page.server.ts
+++ b/src/routes/(app)/(minimal)/invite/[token]/+page.server.ts
@@ -72,7 +72,10 @@ export const actions: Actions = {
 			const result = await createOrUpdateUser({
 				email: existingInvite.email,
 				name: existingInvite.name,
-				emailVerified: true
+				emailVerified: true,
+				// Invited members are onboarded into an existing organization,
+				// so they skip the welcome wizard.
+				showWelcomeWizard: false
 			});
 
 			if (result.userId && existingInvite.organizationId) {


### PR DESCRIPTION
## What

Invited organization members no longer see the welcome wizard.

## Why

The welcome wizard is gated by `user.preferences.showWelcomeWizard`, which `createOrUpdateUser` stamps as `true` on every brand-new account. Accepting an org invite creates the invitee's account through that same path, so invited members were seeing the wizard — even though they're being onboarded into an existing organization, which the wizard's steps (set name → create org → invite teammates → premium promo) don't apply to.

## How

- `createOrUpdateUser` now takes an optional `showWelcomeWizard` param, defaulting to `true` so all existing call sites are unchanged.
- The `acceptInvitation` action passes `showWelcomeWizard: false`.

Only affects **new** invited accounts. Existing users who accept an invite keep their preferences untouched (the on-conflict `updateSet` omits `preferences`).

## Testing

`pnpm check` reports no new errors in the edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)