### PR TITLE
fix(billing): seed & sync Stripe customer email from billing owner

### DIFF
--- a/src/lib/server/form/actions.ts
+++ b/src/lib/server/form/actions.ts
@@ -1,6 +1,6 @@
 import { type Action, error, fail, isRedirect } from '@sveltejs/kit';
 import { timingSafeEqual } from 'crypto';
-import { and, desc, eq, isNull } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
 import type { PostgresError } from 'postgres';
 import { message, setError, superValidate } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
@@ -1448,6 +1448,23 @@ export const confirmEmailChange: Action = async (event) => {
 		} catch (e) {
 			console.error('Failed to sync Stripe customer email.', e);
 		}
+	}
+
+	// Also sync any org Stripe customers where this user is the billing owner —
+	// otherwise the org customer keeps caching the stale personal email.
+	try {
+		const billedOrgs = await db
+			.select({ stripeCustomerId: organization.stripeCustomerId })
+			.from(organization)
+			.where(
+				and(eq(organization.billingOwnerId, user.id), isNotNull(organization.stripeCustomerId))
+			);
+		for (const org of billedOrgs) {
+			if (!org.stripeCustomerId) continue;
+			await stripeInstance.customers.update(org.stripeCustomerId, { email });
+		}
+	} catch (e) {
+		console.error('Failed to sync org Stripe customer emails.', e);
 	}
 
 	try {

--- a/src/lib/server/organization.ts
+++ b/src/lib/server/organization.ts
@@ -69,6 +69,54 @@ export const getOrganizationsByUserId = async (userId: User['id']) =>
 		.innerJoin(organization, eq(membership.organizationId, organization.id))
 		.where(eq(membership.userId, userId));
 
+/**
+ * Resolves the email that should be used for an org's Stripe customer / billing.
+ * Preference order: the designated billing owner (if still a member) → the
+ * provided fallback (typically the acting user) → any org owner.
+ * Stripe stores the only persisted copy of the billing email, so this is the
+ * single source of truth for seeding and re-syncing it.
+ */
+export const getOrgBillingEmail = async (
+	organizationId: Organization['id'],
+	fallbackEmail?: string
+): Promise<string | undefined> => {
+	const [org] = await db
+		.select({ billingOwnerId: organization.billingOwnerId })
+		.from(organization)
+		.where(eq(organization.id, organizationId))
+		.limit(1);
+
+	// Prefer the designated billing owner, but only if they are still a member.
+	if (org?.billingOwnerId) {
+		const [row] = await db
+			.select({ email: user.email })
+			.from(membership)
+			.innerJoin(user, eq(membership.userId, user.id))
+			.where(
+				and(
+					eq(membership.userId, org.billingOwnerId),
+					eq(membership.organizationId, organizationId)
+				)
+			)
+			.limit(1);
+		if (row?.email) return row.email;
+	}
+
+	if (fallbackEmail) return fallbackEmail;
+
+	// Last resort: any owner of the org.
+	const [owner] = await db
+		.select({ email: user.email })
+		.from(membership)
+		.innerJoin(user, eq(membership.userId, user.id))
+		.where(
+			and(eq(membership.organizationId, organizationId), eq(membership.role, MembershipRole.OWNER))
+		)
+		.limit(1);
+
+	return owner?.email;
+};
+
 export const getMembersByOrganizationId = async (organizationId: Organization['id']) =>
 	await db
 		.select({

--- a/src/routes/api/v1/plans/checkout/+server.ts
+++ b/src/routes/api/v1/plans/checkout/+server.ts
@@ -9,7 +9,11 @@ import { getAbsoluteLocalizedUrl } from '$lib/i18n';
 import { m } from '$lib/paraglide/messages.js';
 import { db } from '$lib/server/db';
 import { organization, user } from '$lib/server/db/schema';
-import { getMembersByOrganizationId, getOrganizationsByUserId } from '$lib/server/organization';
+import {
+	getMembersByOrganizationId,
+	getOrganizationsByUserId,
+	getOrgBillingEmail
+} from '$lib/server/organization';
 import stripeInstance from '$lib/server/stripe';
 
 import type { RequestEvent } from '../$types';
@@ -35,9 +39,12 @@ export const POST = async ({ locals, request }: RequestEvent) => {
 		// Get or create Stripe customer for the org
 		let stripeCustomerId = org.stripeCustomerId;
 		if (!stripeCustomerId) {
+			// Seed the customer email from the org's billing owner (not just whoever
+			// runs checkout), falling back to the acting user.
+			const billingEmail = await getOrgBillingEmail(org.id, locals.user.email);
 			const customer = await stripeInstance.customers.create({
 				name: org.name,
-				email: locals.user.email,
+				email: billingEmail,
 				metadata: { organizationId: org.id }
 			});
 			stripeCustomerId = customer.id;


### PR DESCRIPTION
## Problem

The billing owner email is stored correctly in the DB (`organization.billingOwnerId`) but drifts out of sync on Stripe.

Root cause: the org's Stripe customer email is set **once**, at checkout, to whoever runs checkout (`locals.user.email`) — it ignores `billingOwnerId`. The existing billing-owner → Stripe sync calls are all guarded by `if (stripeCustomerId)`, so they silently no-op whenever a billing owner is set/changed *before* the customer exists. Later checkout then seeds the wrong email, and no webhook ever corrects it.

Secondary path: changing a user's personal account email only synced their **personal** Stripe customer, never the **org** customers where they're the billing owner.

## Changes

- **`getOrgBillingEmail()` helper** (`organization.ts`) — resolves the billing email: designated billing owner (if still a member) → fallback (acting user) → any org owner.
- **Checkout** (`api/v1/plans/checkout`) — seed the org Stripe customer email from the billing owner instead of the checkout initiator. *(the actual bug)*
- **Personal email change** (`actions.ts`) — also sync org customers where the user is the billing owner.

The two existing sync paths (explicit billing-owner change, owner-demotion reassignment) are unchanged — they now work reliably because checkout seeds the right email up front.

## Notes / not included

- **Backfill**: already-broken customers won't self-correct until a billing-owner change or the owner's email change fires. A one-off script can push each org's current DB billing email onto its Stripe customer — not in this PR.
- **Invoice emails not sending** is a Stripe Dashboard setting (Settings → Billing → Customer emails → "Email finalized invoices", live mode), not a code change.

## Testing

- `pnpm check` — no new type errors in the touched files (pre-existing project errors unrelated).
- Stripe customer creation isn't exercisable in the local preview; not manually verified against live Stripe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)