### PR TITLE
fix(seo): align sitemap with page canonicals, noindex auth flows

### DIFF
--- a/src/routes/(app)/(minimal)/+layout.svelte
+++ b/src/routes/(app)/(minimal)/+layout.svelte
@@ -8,6 +8,13 @@
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
 </script>
 
+<!-- Every route in this group is an auth or account flow: no search value, and one
+     indexable copy per locale is 14 near-duplicates for Google to reconcile.
+     `follow` still lets link equity pass through to the marketing pages. -->
+<svelte:head>
+	<meta name="robots" content="noindex, follow" />
+</svelte:head>
+
 <Header user={data.user} isPersistent={true} />
 <main>
 	{@render children()}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -8,26 +8,37 @@ import type { RequestHandler } from './$types';
 // Public, crawlable marketing and info pages. Excludes auth flows,
 // account pages, secret retrieval links (/s, /r, /l), the API, and
 // white-label routes (those live on their own custom domains).
-const STATIC_PATHS = [
-	'/',
-	'/about',
-	'/pricing',
-	'/faq',
-	'/contact',
-	'/developers',
-	'/api-documentation',
-	'/security',
-	'/privacy',
-	'/farewell',
-	'/blog',
-	'/alternatives',
-	'/acceptable-use-policy',
-	'/cookie-policy',
-	'/gdpr',
-	'/imprint',
-	'/privacy-policy',
-	'/sla',
-	'/terms-of-service'
+//
+// `localized: false` mirrors `markNotTranslated` on the page itself. Those pages
+// emit an English-only canonical and no hreflang, so advertising alternates here
+// would contradict the markup and leave the locale variants without a canonical
+// Google accepts. Keep the two in sync when a page gains or loses translations.
+const STATIC_PATHS: { path: string; localized?: boolean }[] = [
+	{ path: '/' },
+	{ path: '/about' },
+	{ path: '/pricing' },
+	{ path: '/business' },
+	{ path: '/faq' },
+	{ path: '/contact' },
+	{ path: '/security' },
+	{ path: '/privacy' },
+	{ path: '/farewell' },
+	{ path: '/imprint' },
+	{ path: '/use-cases/customer-support' },
+	{ path: '/use-cases/it-security' },
+	{ path: '/use-cases/journalists' },
+	{ path: '/use-cases/legal-compliance' },
+	{ path: '/api-documentation', localized: false },
+	{ path: '/cli', localized: false },
+	{ path: '/blog', localized: false },
+	{ path: '/alternatives', localized: false },
+	{ path: '/acceptable-use-policy', localized: false },
+	{ path: '/cookie-policy', localized: false },
+	{ path: '/dpa', localized: false },
+	{ path: '/gdpr', localized: false },
+	{ path: '/privacy-policy', localized: false },
+	{ path: '/sla', localized: false },
+	{ path: '/terms-of-service', localized: false }
 ];
 
 const escapeXml = (value: string) =>
@@ -71,7 +82,7 @@ export const GET: RequestHandler = async () => {
 	const posts = await getBlogPosts();
 
 	const entries = [
-		...STATIC_PATHS.map((path) => buildUrlEntry(baseUrl, path)),
+		...STATIC_PATHS.map(({ path, localized }) => buildUrlEntry(baseUrl, path, { localized })),
 		...posts.map((post) =>
 			buildUrlEntry(baseUrl, `/blog/${post.slug}`, {
 				lastmod: new Date(post.date).toISOString(),


### PR DESCRIPTION
## Context

Google Search Console reported **"Duplicate without user-selected canonical"** for a set of localized URLs (`/ja/security`, `/sv/api-documentation`, `/it/blog/comparison-one-time-secret`, `/ru/pricing`, `/sv/use-cases/customer-support`, `/fr/signup`, …).

The missing `<link rel=canonical>` itself **was already fixed** in 2d21f84 (2026-07-15) — before that commit the site emitted hreflang alternates and no canonical at all. The GSC crawl dates (Jul 15–17) straddle that deploy, so the report reflects the pre-fix HTML. I verified all 34 public paths on production: every one already serves a canonical.

This PR fixes the **structural causes still feeding that same bucket**.

## Changes

### Sitemap contradicted the page markup

`STATIC_PATHS` now carries a `localized` flag mirroring `markNotTranslated` on the page.

Nine English-only pages were declared *localized* in the sitemap, advertising 14 hreflang alternates each — while the pages themselves emit no hreflang and canonicalize to the English URL. That contradiction is precisely what leaves `/sv/api-documentation` and the blog posts without a canonical Google accepts.

Also:
- **Added** the four `/use-cases/*` pages, `/business`, `/dpa` and `/cli` — all indexable and internally linked, but unlisted.
- **Removed** `/developers`, which is a **301 → `/api-documentation`**. A redirect in a sitemap is itself a canonical-conflict signal.

38 → 44 URLs.

### Auth flows were indexable in all 14 locales

`/fr/signup` from the report is one of these. Every route in the `(minimal)` group is an auth or account flow, so a single `noindex, follow` in its layout covers signup, login, login/password, reset-password, set-password, verify-email, recover-encryption, encryption, delete-account and invite — and any future one. `follow` still passes link equity through to the marketing pages.

`/upgrade-success` was considered and **deliberately left alone**: it requires both a session and a valid Stripe `session_id`, so it always redirects for a crawler and the tag could never be served.

## Verification

All 44 sitemap entries return 200, carry a canonical, and agree with their page markup on hreflang:

```
sitemap_localized=True   page_localized=True    canonical=yes   ×14
sitemap_localized=False  page_localized=False   canonical=yes   ×30
mismatches/non-200: 0
```

Auth pages emit the new tag, marketing pages do not (the bare `noindex` below is the existing non-production guard in `(app)/+layout.svelte`):

```
/fr/signup     [noindex|noindex, follow]
/login         [noindex|noindex, follow]
/pricing       [noindex]
/de/business   [noindex]
```

`prettier`/`eslint` pass. `pnpm check` reports 45 errors both with and without these changes (pre-existing baseline, none in the touched files).

## Follow-ups (not in this PR)

- `robots.txt` has `Disallow: /s/`, which does not match the bare `/s` page — that one is crawlable.
- The secret-type pages `/text`, `/file`, `/neogram`, `/snap`, `/redirect` are indexable and absent from the sitemap. They have distinct copy, so listing vs. noindexing them is a content call.

After deploy, hit **Validate Fix** on the issue in Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)