### PR TITLE
fix(i18n): reword secret request header to "Request from"

### DIFF
--- a/messages/da.json
+++ b/messages/da.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Indsend krypteret svar",
 	"proud_glad_bear_cheer": "Svar indsendt!",
 	"calm_safe_seal_rest": "Dit svar er blevet sikkert krypteret og indsendt.",
-	"warm_clear_jay_speak": "Besked fra {name} <{email}>",
+	"warm_clear_jay_speak": "Anmodning fra {name} <{email}>",
 	"green_round_duck_trust": "Bekræftet e-mailadresse. Svar kun til personer, du stoler på.",
 	"maroon_heavy_lemur_emerge": "Lås kryptering op",
 	"ornate_fluffy_ox_explore": "Du kan lukke fanen nu.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Verschlüsselte Antwort senden",
 	"proud_glad_bear_cheer": "Antwort übermittelt!",
 	"calm_safe_seal_rest": "Die Antwort wurde sicher verschlüsselt und übermittelt. Nur der Anfragende kann sie entschlüsseln.",
-	"warm_clear_jay_speak": "Nachricht von {name} <{email}>",
+	"warm_clear_jay_speak": "Anfrage von {name} <{email}>",
 	"green_round_duck_trust": "Verifizierte E-Mail-Adresse. Bitte nur vertrauenswürdigen Personen antworten.",
 	"maroon_heavy_lemur_emerge": "Verschlüsselung entsperren",
 	"ornate_fluffy_ox_explore": "Der Tab kann jetzt geschlossen werden.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Submit encrypted response",
 	"proud_glad_bear_cheer": "Response Submitted!",
 	"calm_safe_seal_rest": "Your response has been securely encrypted and submitted.",
-	"warm_clear_jay_speak": "Message from {name} <{email}>",
+	"warm_clear_jay_speak": "Request from {name} <{email}>",
 	"green_round_duck_trust": "Verified email address. Only respond to people you trust.",
 	"maroon_heavy_lemur_emerge": "Unlock encryption",
 	"ornate_fluffy_ox_explore": "You can close the tab now.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Enviar respuesta cifrada",
 	"proud_glad_bear_cheer": "¡Respuesta enviada!",
 	"calm_safe_seal_rest": "Su respuesta ha sido cifrada y enviada de forma segura. Solo el solicitante puede descifrarla.",
-	"warm_clear_jay_speak": "Mensaje de {name} <{email}>",
+	"warm_clear_jay_speak": "Solicitud de {name} <{email}>",
 	"green_round_duck_trust": "Dirección de correo electrónico verificada. Responda solo a personas en las que confíe.",
 	"maroon_heavy_lemur_emerge": "Desbloquear cifrado",
 	"ornate_fluffy_ox_explore": "Ya puedes cerrar la pestaña.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Soumettre la réponse chiffrée",
 	"proud_glad_bear_cheer": "Réponse soumise !",
 	"calm_safe_seal_rest": "Votre réponse a été chiffrée et soumise en toute sécurité. Seul le demandeur peut la déchiffrer.",
-	"warm_clear_jay_speak": "Message de {name} <{email}>",
+	"warm_clear_jay_speak": "Demande de {name} <{email}>",
 	"green_round_duck_trust": "Adresse e-mail vérifiée. Ne répondez qu'aux personnes en qui vous avez confiance.",
 	"maroon_heavy_lemur_emerge": "Déverrouiller le chiffrement",
 	"ornate_fluffy_ox_explore": "Vous pouvez fermer l'onglet maintenant.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Invia risposta crittografata",
 	"proud_glad_bear_cheer": "Risposta inviata!",
 	"calm_safe_seal_rest": "La tua risposta è stata crittografata e inviata in modo sicuro.",
-	"warm_clear_jay_speak": "Messaggio da {name} <{email}>",
+	"warm_clear_jay_speak": "Richiesta da {name} <{email}>",
 	"green_round_duck_trust": "Indirizzo email verificato. Rispondi solo a persone di cui ti fidi.",
 	"maroon_heavy_lemur_emerge": "Sblocca la crittografia",
 	"ornate_fluffy_ox_explore": "Ora puoi chiudere la scheda.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "暗号化された回答を送信",
 	"proud_glad_bear_cheer": "回答を送信しました！",
 	"calm_safe_seal_rest": "あなたの回答は安全に暗号化され、送信されました。",
-	"warm_clear_jay_speak": "{name} <{email}> からのメッセージ",
+	"warm_clear_jay_speak": "{name} <{email}> からのリクエスト",
 	"green_round_duck_trust": "確認済みのメールアドレス。信頼できる相手にのみ回答してください。",
 	"maroon_heavy_lemur_emerge": "暗号化をアンロック",
 	"ornate_fluffy_ox_explore": "タブを閉じても問題ありません。",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Versleuteld antwoord verzenden",
 	"proud_glad_bear_cheer": "Antwoord verzonden!",
 	"calm_safe_seal_rest": "Je antwoord is veilig versleuteld en verzonden.",
-	"warm_clear_jay_speak": "Bericht van {name} <{email}>",
+	"warm_clear_jay_speak": "Verzoek van {name} <{email}>",
 	"green_round_duck_trust": "Geverifieerd e-mailadres. Reageer alleen op mensen die je vertrouwt.",
 	"maroon_heavy_lemur_emerge": "Versleuteling ontgrendelen",
 	"ornate_fluffy_ox_explore": "Je kunt het tabblad nu sluiten.",

--- a/messages/no.json
+++ b/messages/no.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Send inn kryptert svar",
 	"proud_glad_bear_cheer": "Svar sendt inn!",
 	"calm_safe_seal_rest": "Svaret ditt har blitt sikkert kryptert og sendt inn.",
-	"warm_clear_jay_speak": "Melding fra {name} <{email}>",
+	"warm_clear_jay_speak": "Forespørsel fra {name} <{email}>",
 	"green_round_duck_trust": "Bekreftet e-postadresse. Svar kun personer du stoler på.",
 	"maroon_heavy_lemur_emerge": "Lås opp kryptering",
 	"ornate_fluffy_ox_explore": "Du kan lukke fanen nå.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Prześlij zaszyfrowaną odpowiedź",
 	"proud_glad_bear_cheer": "Odpowiedź przesłana!",
 	"calm_safe_seal_rest": "Twoja odpowiedź została bezpiecznie zaszyfrowana i przesłana.",
-	"warm_clear_jay_speak": "Wiadomość od {name} <{email}>",
+	"warm_clear_jay_speak": "Prośba od {name} <{email}>",
 	"green_round_duck_trust": "Zweryfikowany adres e-mail. Odpowiadaj tylko osobom, którym ufasz.",
 	"maroon_heavy_lemur_emerge": "Odblokuj szyfrowanie",
 	"ornate_fluffy_ox_explore": "Możesz teraz zamknąć kartę.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Enviar Resposta Criptografada",
 	"proud_glad_bear_cheer": "Resposta Enviada!",
 	"calm_safe_seal_rest": "Sua resposta foi criptografada e enviada com segurança. Apenas o solicitante pode descriptografá-la.",
-	"warm_clear_jay_speak": "Mensagem de {name} <{email}>",
+	"warm_clear_jay_speak": "Solicitação de {name} <{email}>",
 	"green_round_duck_trust": "Endereço de e-mail verificado. Responda apenas a pessoas em quem confia.",
 	"maroon_heavy_lemur_emerge": "Desbloquear encriptação",
 	"ornate_fluffy_ox_explore": "Pode fechar o separador agora.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Отправить зашифрованный ответ",
 	"proud_glad_bear_cheer": "Ответ отправлен!",
 	"calm_safe_seal_rest": "Ваш ответ был безопасно зашифрован и отправлен. Только отправитель запроса может его расшифровать.",
-	"warm_clear_jay_speak": "Сообщение от {name} <{email}>",
+	"warm_clear_jay_speak": "Запрос от {name} <{email}>",
 	"green_round_duck_trust": "Проверенный адрес электронной почты. Отвечайте только тем людям, которым доверяете.",
 	"maroon_heavy_lemur_emerge": "Разблокировать шифрование",
 	"ornate_fluffy_ox_explore": "Теперь вы можете закрыть вкладку.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "Skicka krypterat svar",
 	"proud_glad_bear_cheer": "Svar inskickat!",
 	"calm_safe_seal_rest": "Ditt svar har krypterats säkert och skickats in.",
-	"warm_clear_jay_speak": "Meddelande från {name} <{email}>",
+	"warm_clear_jay_speak": "Förfrågan från {name} <{email}>",
 	"green_round_duck_trust": "Verifierad e-postadress. Svara bara till personer du litar på.",
 	"maroon_heavy_lemur_emerge": "Lås upp kryptering",
 	"ornate_fluffy_ox_explore": "Du kan stänga fliken nu.",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -802,7 +802,7 @@
 	"bold_true_ram_send": "提交加密回复",
 	"proud_glad_bear_cheer": "回复已提交！",
 	"calm_safe_seal_rest": "您的回复已安全加密并提交。只有请求者才能解密。",
-	"warm_clear_jay_speak": "来自 {name} <{email}> 的消息",
+	"warm_clear_jay_speak": "来自 {name} <{email}> 的请求",
 	"green_round_duck_trust": "已验证的电子邮件地址。只回复您信任的人。",
 	"maroon_heavy_lemur_emerge": "解锁加密",
 	"ornate_fluffy_ox_explore": "您现在可以关闭此标签页了。",

--- a/src/lib/components/blocks/secret-response.svelte
+++ b/src/lib/components/blocks/secret-response.svelte
@@ -75,7 +75,7 @@
 {:else}
 	<Card class="mb-6">
 		<div class="bg-muted mb-6 rounded-lg p-4">
-			<p class="text-muted-foreground mb-1 flex items-center gap-1.5 text-sm font-medium">
+			<p class="text-muted-foreground flex items-center gap-1.5 text-sm font-medium">
 				{m.warm_clear_jay_speak({ name: data.requesterName || '', email: data.requesterEmail })}
 				{#if data.requesterEmailVerified}
 					<Tooltip.Root>


### PR DESCRIPTION
The note on a secret request is optional, so `Message from <name> <email>` read oddly when the requester didn't attach one.

- Reword to `Request from {name} <{email}>` in `en.json` and all 13 other locales (one-line diff per file, no Prettier churn).
- Drop the now-redundant `mb-1` on the header paragraph in `secret-response.svelte`.

No code changes needed beyond the class — the key is used in exactly one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)